### PR TITLE
Make code Python 3.10-compatible

### DIFF
--- a/src/compat.py
+++ b/src/compat.py
@@ -1,3 +1,4 @@
+from typing import NoReturn
 from enum import Enum
 
 
@@ -6,3 +7,6 @@ __all__ = ["StrEnum"]
 class StrEnum(str, Enum):
     __str__ = str.__str__
     __format__ = str.__format__
+
+def assert_never(value: NoReturn) -> NoReturn:
+    raise AssertionError(f"Unhandled value: {value!r}")

--- a/src/compat.py
+++ b/src/compat.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+__all__ = ["StrEnum"]
+
+class StrEnum(str, Enum):
+    __str__ = str.__str__
+    __format__ = str.__format__

--- a/src/context/MqttService.py
+++ b/src/context/MqttService.py
@@ -1,5 +1,4 @@
 import re
-import enum
 import json
 from uuid import UUID, uuid4
 from dataclasses import dataclass
@@ -13,6 +12,7 @@ path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'third_party')
 sys.path.insert(0, path)
 import paho.mqtt.client as mqtt
 
+from ..compat import StrEnum
 from ..domain.waraps import *
 from ..domain.waypoints import GeoPoint
 from ..domain.missionplan import MissionPlan
@@ -41,7 +41,7 @@ class VehicleTaskStateEvent(VehicleEvent):
     tasksAvailable: list[WaraPsAvailableTask]
     tasksExecuting: list[WaraPsExecutingTask]
 
-class MqttConnectionState(enum.StrEnum):
+class MqttConnectionState(StrEnum):
     DISCONNECTED = "disconnected"
     CONNECTED = "connected"
 

--- a/src/domain/missionplan.py
+++ b/src/domain/missionplan.py
@@ -1,4 +1,4 @@
-from typing import Any, Self, Annotated
+from typing import Any, Annotated
 from dataclasses import dataclass, field
 from uuid import UUID, uuid4
 
@@ -19,7 +19,7 @@ class MissionPlan(SchemaMixin):
     # fmt: on
 
     @classmethod
-    def fromJson(cls, data: dict[str, Any]) -> Self:
+    def fromJson(cls, data: dict[str, Any]) -> 'MissionPlan':
         tasks = []
         for c in data["children"]:
             # NOTE: task "name" is actually the type, e.g. move-to

--- a/src/domain/schema.py
+++ b/src/domain/schema.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, fields
 from typing import (get_origin, get_args, get_type_hints,
-                    Annotated, Any, Self, Type, Sequence)
+                    Annotated, Any, Type, Sequence)
 from enum import Enum
 
 __all__ = ["Unit", "Column", "FieldSpec", "Schema"]
@@ -63,7 +63,7 @@ class Schema:
 
     # TODO: cache
     @classmethod
-    def fromDataclass(cls, dtCls) -> Self:
+    def fromDataclass(cls, dtCls) -> 'Schema':
         def unwrapAnnotated(t: Any):
             meta = []
             while get_origin(t) is Annotated:

--- a/src/domain/tasks.py
+++ b/src/domain/tasks.py
@@ -1,9 +1,9 @@
 from typing import (get_type_hints, get_args,
                     Type, ClassVar, Annotated)
 from dataclasses import dataclass, field, fields
-from enum import StrEnum
 from uuid import UUID, uuid4
 
+from ..compat import StrEnum
 from .schema import Schema, SchemaMixin, Unit, Column
 from .waypoints import *
 

--- a/src/domain/tasks.py
+++ b/src/domain/tasks.py
@@ -1,5 +1,5 @@
 from typing import (get_type_hints, get_args,
-                    Type, ClassVar, Self, Annotated)
+                    Type, ClassVar, Annotated)
 from dataclasses import dataclass, field, fields
 from enum import StrEnum
 from uuid import UUID, uuid4
@@ -47,7 +47,7 @@ class Task(SchemaMixin):
     type        : ClassVar[TaskType]
 
     @classmethod
-    def fromJson(cls, data: dict) -> Self:
+    def fromJson(cls, data: dict):
         # This should always be overwritten, as type field determines the subclass
         raise NotImplementedError
 
@@ -124,7 +124,7 @@ class MoveToTask(SingleWaypointTask):
          = MovementSpeedParam.STANDARD
 
     @classmethod
-    def fromJson(cls, data: dict) -> Self:
+    def fromJson(cls, data: dict) -> 'MoveToTask':
         assert(data["name"] == str(cls.type))
         return cls(
             description = str(data["description"]),
@@ -153,7 +153,7 @@ class MovePathTask(MultiWaypointTask):
          = MovementSpeedParam.STANDARD
 
     @classmethod
-    def fromJson(cls, data: dict) -> Self:
+    def fromJson(cls, data: dict) -> 'MovePathTask':
         assert(data["name"] == str(cls.type))
         wps = list(map(GeoPoint.fromJson, data["params"]["waypoints"]))
         return cls(
@@ -178,7 +178,7 @@ class AUVDepthMoveToTask(SingleWaypointTask):
     waypointClass = AUVWaypoint
 
     @classmethod
-    def fromJson(cls, data: dict) -> Self:
+    def fromJson(cls, data: dict) -> 'AUVDepthMoveToTask':
         assert(data["name"] == str(cls.type))
         return cls(
             description = str(data["description"]),
@@ -200,7 +200,7 @@ class AUVDepthMovePathTask(MultiWaypointTask):
     waypointClass = AUVWaypoint
 
     @classmethod
-    def fromJson(cls, data: dict) -> Self:
+    def fromJson(cls, data: dict) -> 'AUVDepthMovePathTask':
         assert(data["name"] == str(cls.type))
         wps = list(map(AUVWaypoint.fromJson, data["params"]["waypoints"]))
         return cls(
@@ -227,7 +227,7 @@ class LoiterTask(Task):
            = .0
 
     @classmethod
-    def fromJson(cls, data: dict) -> Self:
+    def fromJson(cls, data: dict) -> 'LoiterTask':
         assert(data["name"] == str(cls.type))
         return cls(
             description = str(data["description"]),
@@ -253,7 +253,7 @@ class CustomTask(Task):
            = ""
 
     @classmethod
-    def fromJson(cls, data: dict) -> Self:
+    def fromJson(cls, data: dict) -> 'CustomTask':
         assert(data["name"] == str(cls.type))
         return cls(
             description = str(data["description"]),

--- a/src/domain/waypoints.py
+++ b/src/domain/waypoints.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Self
+from typing import Annotated
 from dataclasses import dataclass, field
 from uuid import UUID, uuid4
 
@@ -21,7 +21,7 @@ class Waypoint(SchemaMixin):
     uuid      : UUID = field(default_factory = uuid4, kw_only = True)
 
     @classmethod
-    def fromJson(cls, data: dict) -> Self:
+    def fromJson(cls, data: dict):
         """Load a waypoint from mission plan JSON."""
         # NOTE: This should be implemented by subclasses
         raise NotImplementedError
@@ -65,7 +65,7 @@ class AUVWaypoint(Waypoint):
         }
 
     @classmethod
-    def fromJson(cls, data: dict) -> Self:
+    def fromJson(cls, data: dict) -> 'AUVWaypoint':
         # make sure not parsing a WARA-PS GeoPoint by accident
         if data.get("rostype") == "GeoPoint":
             raise ValueError(f"GeoPoint data passed to {cls.__name__}")
@@ -97,7 +97,7 @@ class GeoPoint(Waypoint):
         }
 
     @classmethod
-    def fromJson(cls, data: dict) -> Self:
+    def fromJson(cls, data: dict) -> 'GeoPoint':
         # make sure we ARE parsing a WARA-PS GeoPoint
         if data.get("rostype") != "GeoPoint":
             raise ValueError(f"Non-GeoPoint data passed to {cls.__name__}")

--- a/src/mission/MissionContext.py
+++ b/src/mission/MissionContext.py
@@ -1,4 +1,3 @@
-from typing import Self
 from pathlib import Path
 from uuid import UUID, uuid4
 import json

--- a/src/mission/MissionDocument.py
+++ b/src/mission/MissionDocument.py
@@ -1,5 +1,5 @@
 from uuid import UUID, uuid4
-from typing import Self, Any, assert_never
+from typing import Any, assert_never
 from pathlib import Path
 import json
 
@@ -58,7 +58,8 @@ class MissionDocument(QObject):
         self._keepalive_undo = []
 
     @classmethod
-    def fromFile(cls, path: str | Path, parent: QObject | None = None) -> Self:
+    def fromFile(cls, path: str | Path,
+                 parent: QObject | None = None) -> 'MissionDocument':
         p = Path(path)
         with p.open() as fp:
             plan = MissionPlan.fromJson(json.load(fp))

--- a/src/mission/MissionDocument.py
+++ b/src/mission/MissionDocument.py
@@ -1,5 +1,5 @@
 from uuid import UUID, uuid4
-from typing import Any, assert_never
+from typing import Any
 from pathlib import Path
 import json
 
@@ -7,6 +7,7 @@ from qgis.PyQt.QtCore import pyqtSlot, pyqtSignal, QObject
 from qgis.PyQt.QtWidgets import QUndoCommand
 from qgis.core import QgsPointXY
 
+from ..compat import assert_never
 from ..domain.missionplan import MissionPlan
 from ..domain.waypoints import Waypoint
 from ..domain.tasks import *

--- a/src/mission/MissionIndex.py
+++ b/src/mission/MissionIndex.py
@@ -1,4 +1,3 @@
-from typing import Self
 from dataclasses import dataclass, field
 from uuid import UUID
 
@@ -14,7 +13,7 @@ class MissionIndex:
     waypointTaskMap: dict[UUID, UUID] = field(default_factory=dict)
 
     @classmethod
-    def fromMissionPlan(cls, plan: MissionPlan) -> Self:
+    def fromMissionPlan(cls, plan: MissionPlan) -> 'MissionIndex':
         index = cls()
         for task in plan.tasks:
             index.registerTask(task)

--- a/src/mission/MissionLayerBridge.py
+++ b/src/mission/MissionLayerBridge.py
@@ -1,4 +1,3 @@
-from typing import assert_never
 from uuid import UUID
 from dataclasses import dataclass
 from contextlib import contextmanager
@@ -6,7 +5,7 @@ from contextlib import contextmanager
 from qgis.PyQt.QtCore import pyqtSlot, pyqtSignal, QObject, QVariant
 from qgis.core import QgsProject, QgsField, QgsFeature, QgsVectorLayer, QgsGeometry, QgsPointXY
 
-from ..compat import StrEnum
+from ..compat import StrEnum, assert_never
 from ..domain.missionplan import MissionPlan
 from ..domain.waypoints import Waypoint
 from ..domain.tasks import Task, SingleWaypointTask, MultiWaypointTask

--- a/src/mission/MissionLayerBridge.py
+++ b/src/mission/MissionLayerBridge.py
@@ -1,5 +1,4 @@
 from typing import assert_never
-from enum import StrEnum
 from uuid import UUID
 from dataclasses import dataclass
 from contextlib import contextmanager
@@ -7,6 +6,7 @@ from contextlib import contextmanager
 from qgis.PyQt.QtCore import pyqtSlot, pyqtSignal, QObject, QVariant
 from qgis.core import QgsProject, QgsField, QgsFeature, QgsVectorLayer, QgsGeometry, QgsPointXY
 
+from ..compat import StrEnum
 from ..domain.missionplan import MissionPlan
 from ..domain.waypoints import Waypoint
 from ..domain.tasks import Task, SingleWaypointTask, MultiWaypointTask

--- a/src/model/WaypointListModel.py
+++ b/src/model/WaypointListModel.py
@@ -8,6 +8,7 @@ from qgis.core import *
 from typing import *
 from uuid import UUID
 
+from ..compat import assert_never
 from ..mission.MissionDocument import MissionDocument
 from ..domain.waypoints import Waypoint
 from ..domain.tasks import WaypointTask, SingleWaypointTask, MultiWaypointTask


### PR DESCRIPTION
Remove usage of `Self`, and provide compat implementations of `StrEnum` and `assert_never`, which are missing from Python 3.10.

Fixes #4 