### PR TITLE
Reproject to epsg:4326

### DIFF
--- a/src/mission/MissionLayerBridge.py
+++ b/src/mission/MissionLayerBridge.py
@@ -65,6 +65,13 @@ class MissionLayerBridge(QObject):
         self._populateLayers(plan)
 
     def _initializeLayers(self, planUuid: UUID) -> None:
+        """
+        Important: The default layer CRS for waypoint layers is set to EPSG:4326.
+
+        This default is dictated by the vehicles. No reprojection of coordinates 
+        needed as long as waypoint layer is initialized with EPSG:4326.
+        """
+
         # Setup waypoint layer
         qgs = QgsProject.instance()
         # Remove any stale layers
@@ -73,7 +80,7 @@ class MissionLayerBridge(QObject):
 
         # Setup our layer
         self.waypointLayer = QgsVectorLayer(
-            'point?crs=epsg:4326',
+            'point?crs=epsg:4326', # IMPORTANT: layer crs set to espg:4326
             f'SMaRCMissionWaypoints-{planUuid}',
             'memory'
         )

--- a/src/mission/MissionMapManager.py
+++ b/src/mission/MissionMapManager.py
@@ -18,8 +18,17 @@ __all__ = ["MissionMapManager"]
 class MyMapTool(QgsMapTool):
     mapClicked = pyqtSignal(QgsPointXY, Qt.MouseButton)
 
+    def _toWgs84(self, point: QgsPointXY) -> QgsPointXY:
+        """Helper to transform a point from map canvas CRS to EPSG:4326 (required)."""
+        canvas_crs = self.canvas().mapSettings().destinationCrs()
+        wgs84 = QgsCoordinateReferenceSystem("EPSG:4326")
+        if canvas_crs == wgs84:
+            return point
+        transform = QgsCoordinateTransform(canvas_crs, wgs84, QgsProject.instance())
+        return transform.transform(point)
+    
     def canvasReleaseEvent(self, e: QgsMapMouseEvent):
-        point = self.toMapCoordinates(e.pos())
+        point = self._toWgs84(self.toMapCoordinates(e.pos()))
         if e.button() == Qt.MouseButton.RightButton:
             # Disable self
             ...


### PR DESCRIPTION
This fix allows for working in different projects (canvas) in QGIS and still plan missions in the correct robot-projection epsg:4326. The fix employs a helper function to reproject map elements to epsg:4326 if they have been created in a different projection in qgis.

Fixes #7 