### PR TITLE
Mission timeout datatype fix

### DIFF
--- a/src/model/MissionParamsModel.py
+++ b/src/model/MissionParamsModel.py
@@ -37,7 +37,18 @@ class MissionParamsModel(SchemaBasedModel):
 
         col = index.column()
 
-        self._doc.setMissionField(col, value)
+        # retrieve the field specification for schema object
+        spec = self._schema.fields[col]
+        # retrieve original value (->type)
+        original = spec.value(self._doc.plan)
+
+        # cast the incoming object to the original type
+        try:
+            typed_value = type(original)(value)
+        except (ValueError, TypeError):
+            return False  # reject invalid input
+
+        self._doc.setMissionField(col, typed_value)
 
         return True
 

--- a/src/model/MissionParamsModel.py
+++ b/src/model/MissionParamsModel.py
@@ -43,8 +43,10 @@ class MissionParamsModel(SchemaBasedModel):
         original = spec.value(self._doc.plan)
 
         # cast the incoming object to the original type
+        # TODO: move conversion to MissionDocument.setMissionField?
         try:
-            typed_value = type(original)(value)
+            typed_value = spec.type()(value) # instead of type(original)(value)
+        
         except (ValueError, TypeError):
             return False  # reject invalid input
 

--- a/src/model/SchemaBasedModel.py
+++ b/src/model/SchemaBasedModel.py
@@ -6,7 +6,7 @@ from .ItemBasedModel import ItemBasedModel
 
 __all__ = ["SchemaBasedModel"]
 
-class SchemaBasedModel(ItemBasedModel):
+class SchemaBasedModel(ItemBasedModel): # TODO: integrate with undo/redo stack
     _schema: Schema
     _longHeaders: bool
 
@@ -53,9 +53,10 @@ class SchemaBasedModel(ItemBasedModel):
         # retrieve original value (->type)
         original = spec.value(item)
 
-        # cast the incoming object to the original type
+        # cast the incoming object to the original type # TODO: move type checks to MissionDocument after undo/redo stack implementation
         try:
-            typed_value = type(original)(value)
+            typed_value = spec.type()(value) # instead of type(original)(value)
+            
         except (ValueError, TypeError):
             return False  # reject invalid input
 

--- a/src/model/SchemaBasedModel.py
+++ b/src/model/SchemaBasedModel.py
@@ -56,7 +56,6 @@ class SchemaBasedModel(ItemBasedModel): # TODO: integrate with undo/redo stack
         # cast the incoming object to the original type # TODO: move type checks to MissionDocument after undo/redo stack implementation
         try:
             typed_value = spec.type()(value) # instead of type(original)(value)
-            
         except (ValueError, TypeError):
             return False  # reject invalid input
 

--- a/src/model/SchemaBasedModel.py
+++ b/src/model/SchemaBasedModel.py
@@ -47,9 +47,19 @@ class SchemaBasedModel(ItemBasedModel):
             return False
 
         item = self._items[index.row()]
-        spec = self._schema.fields[index.column()]
 
-        spec.setValue(item, value)
+        # retrieve the field specification for schema object
+        spec = self._schema.fields[index.column()]
+        # retrieve original value (->type)
+        original = spec.value(item)
+
+        # cast the incoming object to the original type
+        try:
+            typed_value = type(original)(value)
+        except (ValueError, TypeError):
+            return False  # reject invalid input
+
+        spec.setValue(item, typed_value)
         # TODO: or [role]?
         self.dataChanged.emit(index, index, [Qt.DisplayRole, Qt.EditRole])
 


### PR DESCRIPTION
When field values are changed, the entered value retains the original data type.

Fixes and closes #45.
Also closes #22 