### PR TITLE
Improve scratch layers' lifecycle

### DIFF
--- a/src/context/FleetMapManager.py
+++ b/src/context/FleetMapManager.py
@@ -24,7 +24,7 @@ class FleetMapManager(QObject):
     vehicleExpired = pyqtSignal(str)
     vehicleUpdated = pyqtSignal(str)
 
-    _waypointLayer: QgsVectorLayer
+    _waypointLayer: QgsVectorLayer | None = None
 
     def __init__(self, fleetState: FleetState, parent: QObject | None):
         super().__init__(parent)
@@ -234,6 +234,10 @@ class FleetMapManager(QObject):
         if vehicle is None or vehicle.lastFid is None:
             return
 
+        if self._waypointLayer is None:
+            print("Error: Waypoint layer not initialized in onLookAtRequested!")
+            return
+
         iface.mapCanvas().zoomToFeatureIds(self._waypointLayer, [vehicle.lastFid])
         iface.mapCanvas().zoomScale(1000) # zoom to fixed scale (e.g. 1:500)
 
@@ -241,7 +245,7 @@ class FleetMapManager(QObject):
         if self._waypointLayer is None:
             print("Error: Waypoint layer not initialized on clear all!")
             return
-        
+
         # Clear all features from the vector layer
         self._waypointLayer.dataProvider().truncate()
         self._waypointLayer.triggerRepaint()
@@ -253,4 +257,18 @@ class FleetMapManager(QObject):
             vehicle.lastLongitude = None
             vehicle.lastFid = None
 
-    # TODO: cleanup method for vehicleLayers
+    def cleanup(self) -> None:
+        if self._waypointLayer is None:
+            return
+
+        qgs = QgsProject.instance()
+
+        try:
+            layerId = self._waypointLayer.id()
+        except RuntimeError:
+            # Layer may have been removed externally, e.g. during QGIS shutdown
+            pass
+        else:
+            qgs.removeMapLayer(layerId)
+
+        self._waypointLayer = None

--- a/src/context/FleetMapManager.py
+++ b/src/context/FleetMapManager.py
@@ -66,6 +66,11 @@ class FleetMapManager(QObject):
         # Register layer with project
         qgs.addMapLayer(self._waypointLayer, False)
 
+        # Make the layer non-removable (by users)
+        flags = self._waypointLayer.flags()
+        flags &= ~self._waypointLayer.LayerFlag.Removable
+        self._waypointLayer.setFlags(flags)
+
         # Insert the layer at top of layer tree
         QgsProject.instance().layerTreeRoot().insertLayer(0, self._waypointLayer)
 

--- a/src/context/FleetMapManager.py
+++ b/src/context/FleetMapManager.py
@@ -30,12 +30,25 @@ class FleetMapManager(QObject):
         super().__init__(parent)
 
         self._vehicles: dict[str, VehicleMapObject] = {}
-        self._setupWaypointLayer()
+        # If a layer is created at this point, it will mark QgsProject as dirty. This
+        # will cause a popup to appear asking the user whether they want to save or
+        # discard their project changes -- even if no project is loaded!
+        # The solution is to wait until QGIS is fully initialized, and only _then_ add
+        # any layers.
+        # However, if QGIS is already open/initialized, the layer can be created right
+        # away. This happens when the plugin is reloaded.
+        if iface.mainWindow().isVisible():
+            # Plugin reloaded
+            self._setupWaypointLayer()
+        else:
+            # Fresh startup
+            iface.initializationCompleted.connect(self._setupWaypointLayer)
 
         self._fleetState = fleetState
         self._fleetState.vehicleDiscovered.connect(self.onVehicleDiscovered)
         self._fleetState.vehicleUpdated.connect(self.onVehicleUpdated)
 
+    @pyqtSlot()
     def _setupWaypointLayer(self):
         qgs = QgsProject.instance()
         # Remove any stale layers

--- a/src/main.py
+++ b/src/main.py
@@ -109,6 +109,10 @@ class SMaRCMissionControlPlugin(QObject):
         """Called when the plugin is deactivated."""
         self.fleetContext.mqtt.disconnect()
 
+        # Clean up scratch layers created at runtime
+        self.missionContext.cleanup()
+        self.fleetContext.mapManager.cleanup()
+
         # TODO: can be cleaner
         # qgs = QgsProject.instance()
         # for doc in self.missionContext._missionDocuments.values():

--- a/src/mission/MissionContext.py
+++ b/src/mission/MissionContext.py
@@ -3,7 +3,7 @@ from uuid import UUID, uuid4
 import json
 
 from qgis.PyQt.QtCore import pyqtSlot, pyqtSignal, QObject
-from qgis.core import QgsPointXY
+from qgis.core import QgsProject, QgsPointXY
 
 from .MissionMapManager import MissionMapManager
 from .MissionDocument import MissionDocument
@@ -119,3 +119,18 @@ class MissionContext(QObject):
             return
 
         doc.addPendingWaypointTask(pendingTask, point)
+
+    def cleanup(self) -> None:
+        qgs = QgsProject.instance()
+
+        for doc in self._missionDocuments.values():
+            try:
+                layerId = doc.layerBridge.waypointLayer.id()
+            except RuntimeError:
+                # Layer may have been removed externally, e.g. during QGIS shutdown
+                pass
+            else:
+                qgs.removeMapLayer(layerId)
+
+        self._missionDocuments.clear()
+        self._activeDocument = None

--- a/src/mission/MissionLayerBridge.py
+++ b/src/mission/MissionLayerBridge.py
@@ -96,6 +96,11 @@ class MissionLayerBridge(QObject):
 
         qgs.addMapLayer(self.waypointLayer, False)
 
+        # Make the layer non-removable (by users)
+        flags = self.waypointLayer.flags()
+        flags &= ~self.waypointLayer.LayerFlag.Removable
+        self.waypointLayer.setFlags(flags)
+
         # Find or create the f"{self.SMARC_WP_GROUP_NAME}" group at  top of the layer tree
         root = QgsProject.instance().layerTreeRoot()
         wp_group = root.findGroup(f"{self.SMARC_WP_GROUP_NAME}")


### PR DESCRIPTION
Will now properly clean up the scratch layers when the plugin is unloaded. Additionally, this fixes the annoying popup on QGIS startup -- "Do you want to save the current project?" -- which occurs even with an empty project.

Fixes #95 