### PR TITLE
Swap word choice from "Save" to "Commit" for clarity

### DIFF
--- a/src/mission/MissionDocument.py
+++ b/src/mission/MissionDocument.py
@@ -79,8 +79,8 @@ class MissionDocument(QObject):
         self.editingStarted.emit()
         self.editModeChanged.emit(True)
 
-    def stopEditing(self, save: bool):
-        if save:
+    def stopEditing(self, commit: bool):
+        if commit:
             self.layerBridge.waypointLayer.commitChanges()
         else:
             self.layerBridge.waypointLayer.rollBack()

--- a/src/ui/widgets/MissionControlDockWidget.py
+++ b/src/ui/widgets/MissionControlDockWidget.py
@@ -164,16 +164,23 @@ class MissionControlDockWidget(QgsDockWidget):
             doc.startEditing()
         else:
             if doc.isModified():
-                reply = QMessageBox.question(
-                    self,
-                    "Mission plan modified",
-                    "Save changes to mission plan?",
-                    QMessageBox.Save | QMessageBox.Discard | QMessageBox.Cancel,
-                    QMessageBox.Save
-                )
-                if reply == QMessageBox.Save:
+                box = QMessageBox(self)
+                box.setIcon(QMessageBox.Question)
+                box.setWindowTitle("Mission plan modified")
+                box.setText("Commit changes to mission plan?")
+
+                commitButton = box.addButton("Commit", QMessageBox.AcceptRole)
+                discardButton = box.addButton(QMessageBox.Discard)
+                cancelButton = box.addButton(QMessageBox.Cancel)
+
+                box.setDefaultButton(commitButton)
+
+                box.exec()
+                reply = box.clickedButton()
+
+                if reply is commitButton:
                     doc.stopEditing(save = True)
-                elif reply == QMessageBox.Discard:
+                elif reply is discardButton:
                     doc.stopEditing(save = False)
                 else:
                     # User changed their mind, restore button state

--- a/src/ui/widgets/MissionControlDockWidget.py
+++ b/src/ui/widgets/MissionControlDockWidget.py
@@ -179,16 +179,16 @@ class MissionControlDockWidget(QgsDockWidget):
                 reply = box.clickedButton()
 
                 if reply is commitButton:
-                    doc.stopEditing(save = True)
+                    doc.stopEditing(commit = True)
                 elif reply is discardButton:
-                    doc.stopEditing(save = False)
+                    doc.stopEditing(commit = False)
                 else:
                     # User changed their mind, restore button state
                     self.ui.buttonEditMissionPlan.setChecked(True)
                     return
             else:
                 # No changes anyways
-                doc.stopEditing(save = False)
+                doc.stopEditing(commit = False)
 
     @pyqtSlot(bool)
     def onEditModeChanged(self, editMode: bool):


### PR DESCRIPTION
As we agreed, "Commit" makes more sense than "Save". This implementation doesn't have any automatic translations for the word "Commit", but I doubt that's all that important for us.

Fixes #88 