### PR TITLE
fix: edge case where exiting edit mode could ignore the latest change

### DIFF
--- a/src/mission/MissionContext.py
+++ b/src/mission/MissionContext.py
@@ -20,6 +20,7 @@ class MissionContext(QObject):
 
     editModeChanged = pyqtSignal(bool)
     editingStarted = pyqtSignal()
+    editingAboutToFinish = pyqtSignal()
     editingFinished = pyqtSignal()
 
     beforeTaskAdded = pyqtSignal(UUID, int)
@@ -119,6 +120,9 @@ class MissionContext(QObject):
             return
 
         doc.addPendingWaypointTask(pendingTask, point)
+
+    def prepareToFinishEditing(self) -> None:
+        self.editingAboutToFinish.emit()
 
     def cleanup(self) -> None:
         qgs = QgsProject.instance()

--- a/src/ui/widgets/MissionControlDockWidget.py
+++ b/src/ui/widgets/MissionControlDockWidget.py
@@ -163,6 +163,9 @@ class MissionControlDockWidget(QgsDockWidget):
             # Start editing
             doc.startEditing()
         else:
+            # Make sure any pending input field changes are properly recognized
+            self._missionContext.prepareToFinishEditing()
+
             if doc.isModified():
                 box = QMessageBox(self)
                 box.setIcon(QMessageBox.Question)

--- a/src/ui/widgets/MissionPlanWidget.py
+++ b/src/ui/widgets/MissionPlanWidget.py
@@ -45,6 +45,8 @@ class MissionPlanWidget(QWidget):
 
         # Respect edit mode
         self._missionContext.editModeChanged.connect(self.onEditModeChanged)
+        # Make sure any pending changes are submitted
+        self._missionContext.editingAboutToFinish.connect(self._mapper.submit)
 
         # Signals for refreshing the task list
         # TODO

--- a/src/ui/widgets/MissionPlanWidget.py
+++ b/src/ui/widgets/MissionPlanWidget.py
@@ -46,7 +46,7 @@ class MissionPlanWidget(QWidget):
         # Respect edit mode
         self._missionContext.editModeChanged.connect(self.onEditModeChanged)
         # Make sure any pending changes are submitted
-        self._missionContext.editingAboutToFinish.connect(self._mapper.submit)
+        self._missionContext.editingAboutToFinish.connect(self.onEditingAboutToFinish)
 
         # Signals for refreshing the task list
         # TODO
@@ -102,6 +102,20 @@ class MissionPlanWidget(QWidget):
         # Reset task button states
         self.onTaskSelectionChanged(None, None)
 
+    @pyqtSlot()
+    def onEditingAboutToFinish(self) -> None:
+        # Parameter changes
+        self._mapper.submit()
+
+        # Task list (description field) changes
+        editor = self.ui.taskList.focusWidget()
+        if editor is None or editor is self.ui.taskList:
+            # No open editor
+            return
+
+        self.ui.taskList.commitData(editor)
+        self.ui.taskList.closeEditor(editor, QAbstractItemDelegate.NoHint)
+
     @pyqtSlot(bool)
     def onEditModeChanged(self, editMode: bool) -> None:
         self.ui.missionPlanParameters.setEnabled(editMode)
@@ -109,11 +123,6 @@ class MissionPlanWidget(QWidget):
 
         self.taskListModel.setEditable(editMode)
         self._model.setEditable(editMode)
-        # Close current cell editor, if present. This is primarily for the Description
-        # field
-        cellEditor = self.ui.taskList.focusWidget()
-        if cellEditor is not None:
-            self.ui.taskList.closeEditor(cellEditor, QAbstractItemDelegate.NoHint)
 
     @pyqtSlot(QItemSelection, QItemSelection)
     def onTaskSelectionChanged(self, selected: QItemSelection | None,

--- a/src/ui/widgets/WaypointFormWidget.py
+++ b/src/ui/widgets/WaypointFormWidget.py
@@ -50,6 +50,8 @@ class WaypointFormWidget(AutomaticFormWidget):
         self._missionContext.editModeChanged.connect(
             self.onEditModeChanged
         )
+        # Make sure any pending changes are submitted
+        self._missionContext.editingAboutToFinish.connect(self._mapper.submit)
 
         # Handling of the waypoint map tools
         # TODO:

--- a/src/ui/widgets/WaypointTableWidget.py
+++ b/src/ui/widgets/WaypointTableWidget.py
@@ -53,6 +53,8 @@ class WaypointTableWidget(QWidget):
         self._missionContext.editModeChanged.connect(
             self.onEditModeChanged
         )
+        # Make sure any pending changes are submitted
+        self._missionContext.editingAboutToFinish.connect(self.onEditingAboutToFinish)
 
         # Handling of the waypoint map tools
         self.addWaypointRequested.connect(
@@ -119,6 +121,16 @@ class WaypointTableWidget(QWidget):
         # self.ui.buttonMoveWaypointUp.setEnabled(bool(rows) and rows[0].row() > 0)
         # self.ui.buttonMoveWaypointDown.setEnabled(bool(rows) \
         #     and rows[-1].row() < len(self._model.items()) - 1)
+
+    @pyqtSlot()
+    def onEditingAboutToFinish(self):
+        editor = self.ui.waypointTable.focusWidget()
+        if editor is None or editor is self.ui.waypointTable:
+            # No open editor
+            return
+
+        self.ui.waypointTable.commitData(editor)
+        self.ui.waypointTable.closeEditor(editor, QAbstractItemDelegate.NoHint)
 
     @pyqtSlot(bool)
     def onEditModeChanged(self, editMode: bool):


### PR DESCRIPTION
If a user modifies an input field, and clicks "Stop editing" right away (i.e. without changing focus to a different field first), plugin can exit editing mode before submitting/acknowledging the latest change to that input field. This leads either to data loss of the most recent change, or issues with the undo stack. This _should've_ been fine, as clicking the "Stop editing" button means focus is lost on the input field. But this focus loss is processed _after_ the click event is processed for the button.

The solution is to inform all the editor widgets that editing mode is about to finish _after_ the button is clicked, but _before_ any further logic runs, so they have time to submit their changes and close any open cell editors (in tables).

Fixes #8 