### PR TITLE
Properly disable input fields when exiting edit mode.

### DIFF
--- a/src/ui/generated/MissionPlanWidgetUi.py
+++ b/src/ui/generated/MissionPlanWidgetUi.py
@@ -19,7 +19,6 @@ class Ui_MissionPlanWidget(object):
         self.verticalLayout.setContentsMargins(9, 9, 9, 9)
         self.verticalLayout.setObjectName("verticalLayout")
         self.missionPlanParameters = QtWidgets.QWidget(MissionPlanWidget)
-        self.missionPlanParameters.setEnabled(False)
         self.missionPlanParameters.setObjectName("missionPlanParameters")
         self.horizontalLayout_2 = QtWidgets.QHBoxLayout(self.missionPlanParameters)
         self.horizontalLayout_2.setContentsMargins(0, 0, 0, 0)

--- a/src/ui/qtdesigner/MissionPlanWidget.ui
+++ b/src/ui/qtdesigner/MissionPlanWidget.ui
@@ -28,9 +28,6 @@
    </property>
    <item>
     <widget class="QWidget" name="missionPlanParameters" native="true">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
      <layout class="QHBoxLayout" name="horizontalLayout_2">
       <property name="leftMargin">
        <number>0</number>

--- a/src/ui/widgets/AutomaticFormWidget.py
+++ b/src/ui/widgets/AutomaticFormWidget.py
@@ -71,3 +71,18 @@ class AutomaticFormWidget(QWidget):
             return widget
         else:
             raise NotImplementedError
+
+    def _setFieldWidgetEditMode(self, fieldWidget: QWidget, editMode: bool):
+        # Subclasses can overwrite it to be fancier with how they en/disable widgets
+        fieldWidget.setEnabled(editMode)
+
+    def setEditMode(self, editMode: bool):
+        self._model.setEditable(editMode)
+
+        for i in range(self._formLayout.rowCount()):
+            item = self._formLayout.itemAt(i, QFormLayout.FieldRole)
+            if item is None:
+                # Just a label on this row
+                continue
+
+            self._setFieldWidgetEditMode(item.widget(), editMode)

--- a/src/ui/widgets/MissionPlanWidget.py
+++ b/src/ui/widgets/MissionPlanWidget.py
@@ -102,7 +102,8 @@ class MissionPlanWidget(QWidget):
 
     @pyqtSlot(bool)
     def onEditModeChanged(self, editMode: bool) -> None:
-        self.ui.missionPlanParameters.setEnabled(editMode)
+        self.ui.missionPlanDescription.setEnabled(editMode)
+        self.ui.missionPlanTimeout.setEnabled(editMode)
         self.ui.taskListSidebar.setEnabled(editMode)
 
         self.taskListModel.setEditable(editMode)

--- a/src/ui/widgets/TaskEditorWidget.py
+++ b/src/ui/widgets/TaskEditorWidget.py
@@ -61,7 +61,7 @@ class TaskEditorWidget(AutomaticFormWidget):
                 continue
 
             label = QLabel(spec.header(preferLong = True) + ":", self)
-            self._formLayout.addRow(label)
+            self._formLayout.addRow(label, None)
 
             if waypointCls is not None:
                 editor = WaypointFormWidget(taskCls, spec.name, waypointCls,

--- a/src/ui/widgets/TaskEditorWidget.py
+++ b/src/ui/widgets/TaskEditorWidget.py
@@ -79,6 +79,9 @@ class TaskEditorWidget(AutomaticFormWidget):
 
         self._mapper.toFirst()
 
+        # Respect edit mode
+        missionContext.editModeChanged.connect(self.setEditMode)
+
     def _addScalarField(self, spec, column: int):
         label = QLabel(self)
         label.setText(spec.header(preferLong = True) + ":")
@@ -108,3 +111,12 @@ class TaskEditorWidget(AutomaticFormWidget):
 
         for editor in self._editors:
             editor.unbind()
+
+    def _setFieldWidgetEditMode(self, fieldWidget: QWidget, editMode: bool):
+        match fieldWidget:
+            case WaypointFormWidget() | WaypointTableWidget():
+                # They handle edit mode changes themselves
+                pass
+            case _:
+                # Normal editor widgets
+                super()._setFieldWidgetEditMode(fieldWidget, editMode)

--- a/src/ui/widgets/WaypointFormWidget.py
+++ b/src/ui/widgets/WaypointFormWidget.py
@@ -77,7 +77,7 @@ class WaypointFormWidget(AutomaticFormWidget):
 
     @pyqtSlot(bool)
     def onEditModeChanged(self, editMode: bool):
-        self._model.setEditable(editMode)
+        self.setEditMode(editMode)
         self.ui.buttonSelectLocation.setEnabled(editMode)
 
     @pyqtSlot(bool)

--- a/src/ui/widgets/WaypointTableWidget.py
+++ b/src/ui/widgets/WaypointTableWidget.py
@@ -124,6 +124,7 @@ class WaypointTableWidget(QWidget):
     def onEditModeChanged(self, editMode: bool):
         self._model.setEditable(editMode)
         self.ui.waypointTableSideBar.setEnabled(editMode)
+        self.ui.waypointTable.setEnabled(editMode)
 
     @pyqtSlot(bool)
     def onAddWaypointToggled(self, state: bool):


### PR DESCRIPTION
Task editors will now actually enable/disable their input fields on edit mode changes. This is done in a way where labels are _not_ disabled, preserving their contrast and visibility.

Fixes #104 (and potentially #48)