### PR TITLE
Use undo stack for task parameters & description modifications

### DIFF
--- a/src/mission/MissionDocument.py
+++ b/src/mission/MissionDocument.py
@@ -343,3 +343,35 @@ class MissionDocument(QObject):
     def _setWaypointField(self, waypoint: Waypoint, fieldId: int, value: Any):
         waypoint.schema().fields[fieldId].setValue(waypoint, value)
         self.waypointChanged.emit(waypoint.uuid)
+
+    def setTaskField(self, taskUuid: UUID, fieldId: int, value: Any) -> None:
+        task = self.index.taskByUuid(taskUuid)
+        if task is None:
+            # TODO: invalid mapping
+            return
+
+        oldValue = task.schema().fields[fieldId].value(task)
+        cmd = SetTaskFieldUndoCommand(self, task, fieldId, value, oldValue)
+        with self.layerBridge.customEditCommand("Modify task"):
+            self._keepalive_undo.append(cmd)
+            self.layerBridge.waypointLayer.undoStack().push(cmd)
+
+    def _setTaskField(self, task: Task, fieldId: int, value: Any) -> None:
+        task.schema().fields[fieldId].setValue(task, value)
+        self.taskChanged.emit(task.uuid)
+
+    def setTaskDescription(self, taskUuid: UUID, value: str) -> None:
+        task = self.index.taskByUuid(taskUuid)
+        if task is None:
+            # TODO: invalid mapping
+            return
+
+        oldValue = task.description
+        cmd = SetTaskDescriptionUndoCommand(self, task, value, oldValue)
+        with self.layerBridge.customEditCommand("Modify task description"):
+            self._keepalive_undo.append(cmd)
+            self.layerBridge.waypointLayer.undoStack().push(cmd)
+
+    def _setTaskDescription(self, task: Task, value: str) -> None:
+        task.description = value
+        self.taskChanged.emit(task.uuid)

--- a/src/mission/MissionUndoCommand.py
+++ b/src/mission/MissionUndoCommand.py
@@ -18,6 +18,8 @@ __all__ = [
     "DeleteWaypointUndoCommand",
     "SetWaypointPositionUndoCommand",
     "SetWaypointFieldUndoCommand",
+    "SetTaskFieldUndoCommand",
+    "SetTaskDescriptionUndoCommand",
     "SetMissionFieldUndoCommand",
 ]
 
@@ -149,6 +151,49 @@ class SetWaypointFieldUndoCommand(MissionUndoCommand):
     def undo(self):
         print(self.__class__.__name__, 'undo')
         self._doc._setWaypointField(self._waypoint, self._fieldId, self._oldValue)
+
+class SetTaskFieldUndoCommand(MissionUndoCommand):
+    _task: Task
+    _fieldId: int
+    _value: Any
+    _oldValue: Any
+
+    def __init__(self, doc: 'MissionDocument', task: Task, fieldId: int, value: Any,
+                 oldValue: Any):
+        super().__init__(doc)
+
+        self._task = task
+        self._fieldId = fieldId
+        self._value = value
+        self._oldValue = oldValue
+
+    def redo(self):
+        print(self.__class__.__name__, 'redo')
+        self._doc._setTaskField(self._task, self._fieldId, self._value)
+
+    def undo(self):
+        print(self.__class__.__name__, 'undo')
+        self._doc._setTaskField(self._task, self._fieldId, self._oldValue)
+
+class SetTaskDescriptionUndoCommand(MissionUndoCommand):
+    _task: Task
+    _value: str
+    _oldValue: str
+
+    def __init__(self, doc: 'MissionDocument', task: Task, value: str, oldValue: str):
+        super().__init__(doc)
+
+        self._task = task
+        self._value = value
+        self._oldValue = oldValue
+
+    def redo(self):
+        print(self.__class__.__name__, 'redo')
+        self._doc._setTaskDescription(self._task, self._value)
+
+    def undo(self):
+        print(self.__class__.__name__, 'undo')
+        self._doc._setTaskDescription(self._task, self._oldValue)
 
 class SetMissionFieldUndoCommand(MissionUndoCommand):
     _value: Any

--- a/src/model/SchemaBasedModel.py
+++ b/src/model/SchemaBasedModel.py
@@ -40,27 +40,3 @@ class SchemaBasedModel(ItemBasedModel): # TODO: integrate with undo/redo stack
         spec = self._schema.fields[index.column()]
         # TODO: always str?
         return str(spec.value(item))
-
-    def setData(self, index: QModelIndex, value: QVariant,
-                role: int = Qt.EditRole) -> bool:
-        if role != Qt.EditRole:
-            return False
-
-        item = self._items[index.row()]
-
-        # retrieve the field specification for schema object
-        spec = self._schema.fields[index.column()]
-        # retrieve original value (->type)
-        original = spec.value(item)
-
-        # cast the incoming object to the original type # TODO: move type checks to MissionDocument after undo/redo stack implementation
-        try:
-            typed_value = spec.type()(value) # instead of type(original)(value)
-        except (ValueError, TypeError):
-            return False  # reject invalid input
-
-        spec.setValue(item, typed_value)
-        # TODO: or [role]?
-        self.dataChanged.emit(index, index, [Qt.DisplayRole, Qt.EditRole])
-
-        return True

--- a/src/model/TaskListModel.py
+++ b/src/model/TaskListModel.py
@@ -5,24 +5,38 @@ from qgis.PyQt.QtWidgets import *
 from qgis.gui import *
 from qgis.core import *
 
+from uuid import UUID
+
 from ..domain.tasks import Task
-from ..domain.missionplan import MissionPlan
+from ..mission.MissionDocument import MissionDocument
 from .ItemBasedModel import ItemBasedModel
 
 __all__ = ["TaskListModel"]
 
 class TaskListModel(ItemBasedModel):
-    _plan: MissionPlan | None
+    _doc: MissionDocument | None
     _items: list[Task]
     _columns: list[str] = ["Description", "Type"]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._plan = None
+        self._doc = None
 
-    def setMissionPlan(self, plan: MissionPlan | None):
-        self._plan = plan
-        self.setItems(plan.tasks if plan else [])
+    def bind(self, doc: MissionDocument) -> None:
+        self.unbind()
+
+        self._doc = doc
+
+        self.setItems(self._doc.plan.tasks)
+
+        self._doc.taskChanged.connect(self.onTaskChanged)
+
+    def unbind(self) -> None:
+        if self._doc is not None:
+            self._doc.taskChanged.disconnect(self.onTaskChanged)
+
+        self._doc = None
+        self.setItems([])
 
     def columnCount(self, parent: QModelIndex = QModelIndex()) -> int:
         return 0 if parent.isValid() else len(self._columns)
@@ -62,17 +76,36 @@ class TaskListModel(ItemBasedModel):
 
     def setData(self, index: QModelIndex, value: QVariant,
                 role: int = Qt.EditRole) -> bool:
-        if role != Qt.EditRole:
+        if role != Qt.EditRole or not self.isEditable() or self._doc is None:
             return False
 
         task = self._items[index.row()]
         col = index.column()
         if col == 0:
-            task.description = str(value)
-            self.dataChanged.emit(index, index, [Qt.DisplayRole, Qt.EditRole])
+            self._doc.setTaskDescription(task.uuid, str(value))
             return True
         else:
             # TODO: report an error, this is a bug; only task description can be changed
             pass
 
         return False
+
+    def _rowForUuid(self, taskUuid: UUID) -> int | None:
+        for row, task in enumerate(self.items()):
+            if task.uuid == taskUuid:
+                return row
+        return None
+
+    @pyqtSlot(UUID)
+    def onTaskChanged(self, taskUuid: UUID) -> None:
+        if self._doc is None:
+            return
+
+        taskIndex = self._rowForUuid(taskUuid)
+        if taskIndex is None:
+            # TODO: change to a task not managed by this model? This shouldn't happen
+            return
+
+        idxStart = self.index(taskIndex, 0)
+        idxEnd = self.index(taskIndex, self.columnCount() - 1)
+        self.dataChanged.emit(idxStart, idxEnd, [Qt.DisplayRole, Qt.EditRole])

--- a/src/model/TaskParamsModel.py
+++ b/src/model/TaskParamsModel.py
@@ -1,0 +1,86 @@
+from qgis.PyQt import uic
+from qgis.PyQt.QtCore import *
+from qgis.PyQt.QtGui import *
+from qgis.PyQt.QtWidgets import *
+from qgis.gui import *
+from qgis.core import *
+
+from typing import *
+from uuid import UUID
+
+from ..domain.tasks import Task
+from ..domain.schema import Schema
+from ..mission.MissionDocument import MissionDocument
+from .SchemaBasedModel import SchemaBasedModel
+
+__all__ = ["TaskParamsModel"]
+
+class TaskParamsModel(SchemaBasedModel):
+    _doc: MissionDocument | None
+    _task: Task | None
+
+    def __init__(self, taskCls: Type[Task]):
+        super().__init__(taskCls.schema(), longHeaders = True)
+
+        self._doc = None
+        self._task = None
+
+    def bind(self, doc: MissionDocument, taskUuid: UUID) -> None:
+        task = doc.index.taskByUuid(taskUuid)
+        if task is None:
+            return
+
+        self.unbind()
+
+        self._doc = doc
+        self._task = task
+
+        self.setItems([task])
+
+        self._doc.taskChanged.connect(self.onTaskChanged)
+
+    def unbind(self) -> None:
+        if self._doc is not None:
+            self._doc.taskChanged.disconnect(self.onTaskChanged)
+
+        self._doc = None
+        self._task = None
+        self.setItems([])
+
+    def flags(self, index: QModelIndex) -> Qt.ItemFlags:
+        flags = super().flags(index)
+        if self.isEditable():
+            flags |= Qt.ItemIsEditable
+        return flags
+
+    def setData(self, index: QModelIndex, value: QVariant,
+                role: int = Qt.EditRole) -> bool:
+        if role != Qt.EditRole or not self.isEditable():
+            return False
+        if self._doc is None or self._task is None:
+            # TODO: invalid mapping
+            return False
+
+        col = index.column()
+        task = self.item(index.row())
+
+        # Should only ever be scalar fields, as e.g. waypoints, etc. have custom
+        # widgets, which will not trigger setData calls
+        field = task.schema().fields[col]
+        # TODO: a better, unified way of type conversions is in order
+        if field.type()(value) == field.value(task):
+            # No change! Nothing to do.
+            return False
+
+        # TODO: have it return bool as status
+        self._doc.setTaskField(task.uuid, col, field.type()(value))
+        return True
+
+    @pyqtSlot(UUID)
+    def onTaskChanged(self, taskUuid: UUID) -> None:
+        if self._doc is None or self._task is None:
+            return
+
+        idxStart = self.index(0, 0)
+        idxEnd = self.index(0, self.columnCount() - 1)
+        self.dataChanged.emit(idxStart, idxEnd, [Qt.DisplayRole, Qt.EditRole])

--- a/src/ui/widgets/MissionPlanWidget.py
+++ b/src/ui/widgets/MissionPlanWidget.py
@@ -95,8 +95,7 @@ class MissionPlanWidget(QWidget):
 
     @pyqtSlot(MissionDocument)
     def onActiveMissionChanged(self, doc: MissionDocument) -> None:
-        # TODO: accept doc like other models
-        self.taskListModel.setMissionPlan(doc.plan)
+        self.taskListModel.bind(doc)
         self._model.bind(doc)
         self._mapper.toFirst()
         # Reset task button states

--- a/src/ui/widgets/TaskEditorWidget.py
+++ b/src/ui/widgets/TaskEditorWidget.py
@@ -12,13 +12,10 @@ from uuid import UUID, uuid4
 
 from ...domain.tasks import Task
 from ...domain.schema import Schema
-from ...domain.taskspatial import (isWaypointField, isWaypointListField,
-                                   waypointListType, waypointType)
+from ...domain.taskspatial import waypointListType, waypointType
 from ...mission.MissionContext import MissionContext
 from ...mission.MissionDocument import MissionDocument
-from ...model.SchemaBasedModel import SchemaBasedModel
-
-# from ..tasksUi import TaskUiRegistry
+from ...model.TaskParamsModel import TaskParamsModel
 
 from .AutomaticFormWidget import AutomaticFormWidget
 from .WaypointFormWidget import WaypointFormWidget
@@ -31,16 +28,9 @@ class TaskEditorWidget(AutomaticFormWidget):
 
     def __init__(self, taskCls: Type[Task], missionContext: MissionContext,
                  parent: QWidget | None = None):
-        schema = taskCls.schema()
-        scalarFields = [
-            spec for spec in schema.fields
-            if not isWaypointField(spec) and not isWaypointListField(spec)
-        ]
-        self._model = SchemaBasedModel(
-            Schema(scalarFields), longHeaders = True)
+        self._model = TaskParamsModel(taskCls)
         super().__init__(self._model, parent)
 
-        self._taskCls = taskCls
         self._editors = []
 
         self.setContentsMargins(0, 0, 0, 0)
@@ -51,15 +41,12 @@ class TaskEditorWidget(AutomaticFormWidget):
             Qt.AlignRight|Qt.AlignTrailing|Qt.AlignVCenter)
         self._formLayout.setFormAlignment(Qt.AlignTop)
 
-        scalarColumns = {
-            spec.name: column for column, spec in enumerate(scalarFields)
-        }
-        for spec in schema.fields:
+        for index, spec in enumerate(self._model.schema().fields):
             waypointCls = waypointType(spec.baseType)
             waypointListCls = waypointListType(spec.baseType)
 
             if waypointCls is None and waypointListCls is None:
-                self._addScalarField(spec, scalarColumns[spec.name])
+                self._addScalarField(spec, index)
                 continue
 
             label = QLabel(spec.header() + ":", self)
@@ -100,17 +87,14 @@ class TaskEditorWidget(AutomaticFormWidget):
             self._mapper.addMapping(field, column)
 
     def bind(self, doc: MissionDocument, taskUuid: UUID):
-        task = doc.index.taskByUuid(taskUuid)
-        assert(task)
-        assert(isinstance(task, self._taskCls))
-        self._model.setItems([task])
+        self._model.bind(doc, taskUuid)
         self._mapper.toFirst()
 
         for editor in self._editors:
             editor.bind(doc, taskUuid)
 
     def unbind(self):
-        self._model.setItems([])
+        self._model.unbind()
 
         for editor in self._editors:
             editor.unbind()

--- a/src/ui/widgets/TaskEditorWidget.py
+++ b/src/ui/widgets/TaskEditorWidget.py
@@ -27,6 +27,8 @@ from .WaypointTableWidget import WaypointTableWidget
 __all__ = ['TaskEditorWidget']
 
 class TaskEditorWidget(AutomaticFormWidget):
+    _editors: list[QWidget]
+
     def __init__(self, taskCls: Type[Task], missionContext: MissionContext,
                  parent: QWidget | None = None):
         schema = taskCls.schema()
@@ -60,9 +62,10 @@ class TaskEditorWidget(AutomaticFormWidget):
                 self._addScalarField(spec, scalarColumns[spec.name])
                 continue
 
-            label = QLabel(spec.header(preferLong = True) + ":", self)
+            label = QLabel(spec.header() + ":", self)
             self._formLayout.addRow(label, None)
 
+            editor: QWidget
             if waypointCls is not None:
                 editor = WaypointFormWidget(taskCls, spec.name, waypointCls,
                                             missionContext, self)
@@ -84,7 +87,7 @@ class TaskEditorWidget(AutomaticFormWidget):
 
     def _addScalarField(self, spec, column: int):
         label = QLabel(self)
-        label.setText(spec.header(preferLong = True) + ":")
+        label.setText(spec.header() + ":")
 
         field = self.createEditorWidget(self, spec.type())
         self._formLayout.addRow(label, field)

--- a/src/ui/widgets/TaskEditorWidget.py
+++ b/src/ui/widgets/TaskEditorWidget.py
@@ -71,6 +71,8 @@ class TaskEditorWidget(AutomaticFormWidget):
 
         # Respect edit mode
         missionContext.editModeChanged.connect(self.setEditMode)
+        # Make sure any pending changes are submitted
+        missionContext.editingAboutToFinish.connect(self._mapper.submit)
 
     def _addScalarField(self, spec, column: int):
         label = QLabel(self)


### PR DESCRIPTION
Modifications of task parameters and description will now use the undo stack, same as modification of waypoint and mission plan parameters. With this change, all the input field modifications done in the mission planning interface should properly make use of the undo stack.

Fixes #5 