### PR TITLE
Implement tracks between waypoints

### DIFF
--- a/src/mission/MissionContext.py
+++ b/src/mission/MissionContext.py
@@ -131,16 +131,8 @@ class MissionContext(QObject):
         self.editingAboutToFinish.emit()
 
     def cleanup(self) -> None:
-        qgs = QgsProject.instance()
-
         for doc in self._missionDocuments.values():
-            try:
-                layerId = doc.layerBridge.waypointLayer.id()
-            except RuntimeError:
-                # Layer may have been removed externally, e.g. during QGIS shutdown
-                pass
-            else:
-                qgs.removeMapLayer(layerId)
+            doc.layerBridge.cleanup()
 
         self._missionDocuments.clear()
         self._activeDocument = None

--- a/src/mission/MissionContext.py
+++ b/src/mission/MissionContext.py
@@ -25,7 +25,7 @@ class MissionContext(QObject):
 
     beforeTaskAdded = pyqtSignal(UUID, int)
     taskAdded = pyqtSignal(UUID, int)
-    taskListModified = pyqtSignal()
+    taskDeleted = pyqtSignal(UUID, int)
 
     _missionDocuments: dict[UUID, MissionDocument]
     _activeDocument: UUID | None
@@ -43,17 +43,19 @@ class MissionContext(QObject):
         doc.editModeChanged.disconnect(self.editModeChanged)
         doc.editingStarted.disconnect(self.editingStarted)
         doc.editingFinished.disconnect(self.editingFinished)
-        doc.taskListModified.disconnect(self.taskListModified)
+
         doc.beforeTaskAdded.disconnect(self.beforeTaskAdded)
         doc.taskAdded.disconnect(self.taskAdded)
+        doc.taskDeleted.disconnect(self.taskDeleted)
 
     def _bindDocument(self, doc: MissionDocument):
         doc.editModeChanged.connect(self.editModeChanged)
         doc.editingStarted.connect(self.editingStarted)
         doc.editingFinished.connect(self.editingFinished)
-        doc.taskListModified.connect(self.taskListModified)
+
         doc.beforeTaskAdded.connect(self.beforeTaskAdded)
         doc.taskAdded.connect(self.taskAdded)
+        doc.taskDeleted.connect(self.taskDeleted)
 
     def activeDocument(self) -> MissionDocument | None:
         if self._activeDocument is None:

--- a/src/mission/MissionContext.py
+++ b/src/mission/MissionContext.py
@@ -4,6 +4,7 @@ import json
 
 from qgis.PyQt.QtCore import pyqtSlot, pyqtSignal, QObject
 from qgis.core import QgsProject, QgsPointXY
+from qgis.utils import iface
 
 from .MissionMapManager import MissionMapManager
 from .MissionDocument import MissionDocument
@@ -105,6 +106,9 @@ class MissionContext(QObject):
         doc = self.activeDocument()
         assert(doc)
         self._bindDocument(doc)
+
+        # Activate the corresponding waypoint layer
+        iface.setActiveLayer(doc.layerBridge.waypointLayer)
 
         self.activeMissionChanged.emit(doc)
 

--- a/src/mission/MissionDocument.py
+++ b/src/mission/MissionDocument.py
@@ -25,9 +25,6 @@ class MissionDocument(QObject):
     editingStarted = pyqtSignal()
     editingFinished = pyqtSignal()
 
-    # TODO: remove
-    taskListModified = pyqtSignal()
-
     # TODO: not very precise
     missionChanged = pyqtSignal()
 
@@ -172,7 +169,6 @@ class MissionDocument(QObject):
 
         self.plan.tasks.insert(index, task)
         self.index.registerTask(task)
-        self.taskListModified.emit()
 
         self.taskAdded.emit(task.uuid, index)
 
@@ -195,9 +191,14 @@ class MissionDocument(QObject):
             self.layerBridge.waypointLayer.undoStack().push(cmd)
 
     def _deleteTaskAt(self, index: int):
-        task = self.plan.tasks.pop(index)
+        task = self.plan.tasks[index]
+
+        self.beforeTaskDeleted.emit(task.uuid)
+
+        self.plan.tasks.pop(index)
         self.index.forgetTask(task.uuid)
-        self.taskListModified.emit()
+
+        self.taskDeleted.emit(task.uuid, index)
 
     # TODO: move task to a specific index
     # def moveTask(self, taskUuid: UUID, index: int): ...

--- a/src/mission/MissionIndex.py
+++ b/src/mission/MissionIndex.py
@@ -9,13 +9,14 @@ from ..domain.taskspatial import iterTaskWaypoints
 
 @dataclass
 class MissionIndex:
+    plan: MissionPlan
     waypointMap: dict[UUID, Waypoint] = field(default_factory=dict)
     taskMap: dict[UUID, Task] = field(default_factory=dict)
     waypointTaskMap: dict[UUID, UUID] = field(default_factory=dict)
 
     @classmethod
     def fromMissionPlan(cls, plan: MissionPlan) -> 'MissionIndex':
-        index = cls()
+        index = cls(plan)
         for task in plan.tasks:
             index.registerTask(task)
 
@@ -26,6 +27,9 @@ class MissionIndex:
 
     def taskByUuid(self, taskUuid: UUID) -> Task | None:
         return self.taskMap.get(taskUuid)
+
+    def taskUuidByWaypointUuid(self, waypointUuid: UUID) -> UUID | None:
+        return self.waypointTaskMap.get(waypointUuid)
 
     def taskByWaypointUuid(self, waypointUuid: UUID) -> Task | None:
         taskUuid = self.waypointTaskMap.get(waypointUuid)
@@ -69,3 +73,59 @@ class MissionIndex:
 
         del self.waypointMap[waypointUuid]
         del self.waypointTaskMap[waypointUuid]
+
+    def previousWaypointByUuid(self, waypointUuid: UUID) -> Waypoint | None:
+        task = self.taskByWaypointUuid(waypointUuid)
+        waypoint = self.waypointByUuid(waypointUuid)
+        if not all((task, waypoint)):
+            # TODO: invalid mapping
+            return None
+
+        waypoints = list(iterTaskWaypoints(task))
+        index = waypoints.index(waypoint)
+
+        if index == 0:
+            # Previous on a previous task
+            taskIndex = self.plan.tasks.index(task)
+            taskIndex -= 1
+            while taskIndex >= 0:
+                task = self.plan.tasks[taskIndex]
+                waypoints = list(iterTaskWaypoints(task))
+                if len(waypoints):
+                    # Task has waypoints, last one is the one we are looking for
+                    return waypoints[-1]
+                taskIndex -= 1
+
+            # No tasks before this one have waypoints
+            return None
+        else:
+            # Previous waypoint on same task
+            return waypoints[index - 1]
+
+    def nextWaypointByUuid(self, waypointUuid: UUID) -> Waypoint | None:
+        task = self.taskByWaypointUuid(waypointUuid)
+        waypoint = self.waypointByUuid(waypointUuid)
+        if not all((task, waypoint)):
+            # TODO: invalid mapping
+            return None
+
+        waypoints = list(iterTaskWaypoints(task))
+        index = waypoints.index(waypoint)
+
+        if index == len(waypoints) - 1:
+            # Next on a following task
+            taskIndex = self.plan.tasks.index(task)
+            taskIndex += 1
+            while taskIndex < len(self.plan.tasks):
+                task = self.plan.tasks[taskIndex]
+                waypoints = list(iterTaskWaypoints(task))
+                if len(waypoints):
+                    # Task has waypoints, first one is the one we are looking for
+                    return waypoints[0]
+                taskIndex += 1
+
+            # No tasks before this one have waypoints
+            return None
+        else:
+            # Next waypoint on same task
+            return waypoints[index + 1]

--- a/src/mission/MissionLayerBridge.py
+++ b/src/mission/MissionLayerBridge.py
@@ -308,4 +308,25 @@ class MissionLayerBridge(QObject):
         point = QgsPointXY(longitude, latitude)
         self.waypointLayer.changeGeometry(fid, QgsGeometry.fromPointXY(point))
 
-    # TODO: cleanup method for MissionPlanLayers
+    def cleanup(self) -> None:
+        qgs = QgsProject.instance()
+
+        try:
+            layerId = self.waypointLayer.id()
+        except RuntimeError:
+            # Layer may have been removed externally, e.g. during QGIS shutdown
+            pass
+        else:
+            qgs.removeMapLayer(layerId)
+
+        try:
+            layerId = self.tracks._layer.id()
+        except RuntimeError:
+            # Layer may have been removed externally, e.g. during QGIS shutdown
+            pass
+        else:
+            qgs.removeMapLayer(layerId)
+
+        root = QgsProject.instance().layerTreeRoot()
+
+        self._layerGroup.parent().removeChildNode(self._layerGroup)

--- a/src/mission/MissionLayerBridge.py
+++ b/src/mission/MissionLayerBridge.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from contextlib import contextmanager
 
 from qgis.PyQt.QtCore import pyqtSlot, pyqtSignal, QObject, QVariant
-from qgis.core import QgsProject, QgsField, QgsFeature, QgsVectorLayer, QgsGeometry, QgsPointXY
+from qgis.core import QgsProject, QgsField, QgsFeature, QgsVectorLayer, QgsGeometry, QgsPointXY, QgsLayerTreeGroup
 
 from ..compat import StrEnum, assert_never
 from ..domain.missionplan import MissionPlan
@@ -41,7 +41,8 @@ class MissionLayerBridge(QObject):
         QGIS_EDIT_COMMAND = 'qgis-edit-command'
         CUSTOM_EDIT_COMMAND = 'custom-edit-command'
         REPLAYING_QGIS_COMMAND = 'replaying-qgis-command'
-    SMARC_WP_GROUP_NAME = 'SMaRCMissionWaypoints'
+
+    SMARC_GROUP_NAME = 'SMaRCMissions'
 
     waypointMoved = pyqtSignal(UUID, QgsPointXY)
     waypointAdded = pyqtSignal(UUID, UUID, QgsPointXY)
@@ -52,6 +53,7 @@ class MissionLayerBridge(QObject):
     _state: State
     _journal: list[JournalEntry]
 
+    _layerGroup: QgsLayerTreeGroup
     waypointLayer: QgsVectorLayer
     trackLayer: QgsVectorLayer
 
@@ -64,8 +66,29 @@ class MissionLayerBridge(QObject):
         self._state = self.State.DEFAULT
         self._journal = []
 
+        self._setupLayerGroup(plan.uuid)
         self._initializeLayers(plan.uuid)
         self._populateLayers(plan)
+
+    def _setupLayerGroup(self, planUuid: UUID) -> None:
+        # Find or create the SMaRCMissions group at the top of the layer tree
+        qgs = QgsProject.instance()
+        root = qgs.layerTreeRoot()
+        smarcgroup = root.findGroup(self.SMARC_GROUP_NAME)
+        if smarcgroup is None:
+            smarcgroup = root.insertGroup(0, self.SMARC_GROUP_NAME)
+
+        # Find or create group for this mission plan
+        name = f"{planUuid}"
+        layerGroup = root.findGroup(name)
+        if layerGroup is None:
+            layerGroup = smarcgroup.insertGroup(0, name)
+        else:
+            # Make sure it's clear of any leftover layers
+            print(layerGroup, layerGroup.findLayers())
+            qgs.removeMapLayers([node.layer() for node in layerGroup.findLayers()])
+
+        self._layerGroup = layerGroup
 
     def _initializeLayers(self, planUuid: UUID) -> None:
         """
@@ -76,15 +99,9 @@ class MissionLayerBridge(QObject):
         """
 
         # Setup waypoint layer
-        qgs = QgsProject.instance()
-        # Remove any stale layers
-        matching = qgs.mapLayersByName(f'{self.SMARC_WP_GROUP_NAME}-{planUuid}')
-        qgs.removeMapLayers([l.id() for l in matching])
-
-        # Setup our layer
         self.waypointLayer = QgsVectorLayer(
             'point?crs=epsg:4326', # IMPORTANT: layer crs set to espg:4326
-            f'{self.SMARC_WP_GROUP_NAME}-{planUuid}',
+            f'Waypoints',
             'memory'
         )
         self.waypointLayer.dataProvider().addAttributes([
@@ -94,22 +111,18 @@ class MissionLayerBridge(QObject):
         ])
         self.waypointLayer.updateFields()
 
-        qgs.addMapLayer(self.waypointLayer, False)
-
         # Make the layer non-removable (by users)
         flags = self.waypointLayer.flags()
         flags &= ~self.waypointLayer.LayerFlag.Removable
         self.waypointLayer.setFlags(flags)
 
-        # Find or create the f"{self.SMARC_WP_GROUP_NAME}" group at  top of the layer tree
-        root = QgsProject.instance().layerTreeRoot()
-        wp_group = root.findGroup(f"{self.SMARC_WP_GROUP_NAME}")
-        if wp_group is None:
-            wp_group = root.insertGroup(0, f"{self.SMARC_WP_GROUP_NAME}")
-        wp_group.addLayer(self.waypointLayer)
+        # Register the layer with QGIS and add it to the group
+        QgsProject().instance().addMapLayer(self.waypointLayer, False)
+        self._layerGroup.addLayer(self.waypointLayer)
 
         #TODO auto-select/highlight newly created layer
 
+        # Register layer callbacks
         self.waypointLayer.featureAdded.connect(self.onFeatureAdded)
         self.waypointLayer.featureDeleted.connect(self.onFeatureDeleted)
         self.waypointLayer.geometryChanged.connect(self.onGeometryChanged)

--- a/src/mission/MissionLayerBridge.py
+++ b/src/mission/MissionLayerBridge.py
@@ -10,6 +10,7 @@ from ..domain.missionplan import MissionPlan
 from ..domain.waypoints import Waypoint
 from ..domain.tasks import Task
 from ..domain.taskspatial import iterTaskWaypoints
+from .MissionTracks import MissionTracks
 
 
 __all__ = ["MissionLayerBridge"]
@@ -55,8 +56,7 @@ class MissionLayerBridge(QObject):
 
     _layerGroup: QgsLayerTreeGroup
     waypointLayer: QgsVectorLayer
-    trackLayer: QgsVectorLayer
-
+    tracks: MissionTracks
 
     def __init__(self, plan: MissionPlan, parent: QObject | None = None) -> None:
         super().__init__(parent)
@@ -129,6 +129,11 @@ class MissionLayerBridge(QObject):
 
         self.waypointLayer.editCommandStarted.connect(self.onEditCommandStarted)
         self.waypointLayer.editCommandEnded.connect(self.onEditCommandEnded)
+
+        # Setup the tracks layer
+        # Use same color as the waypoint layer
+        color = self.waypointLayer.renderer().symbol().color()
+        self.tracks = MissionTracks(self.parent(), self._layerGroup, color, self)
 
     def _populateLayers(self, plan: MissionPlan) -> None:
         for task in plan.tasks:

--- a/src/mission/MissionTracks.py
+++ b/src/mission/MissionTracks.py
@@ -1,0 +1,384 @@
+from ..domain.missionplan import MissionPlan
+from ..domain.waypoints import Waypoint
+from ..domain.taskspatial import iterTaskWaypoints
+
+from qgis.core import *
+from qgis.PyQt.QtCore import Qt, QObject, pyqtSlot, pyqtSignal, QVariant
+from qgis.PyQt.QtGui import QColor
+
+from uuid import UUID
+
+
+__all__ = ["MissionTracks"]
+
+
+class MissionTracks(QObject):
+    _doc: 'MissionDocument'
+    _layer: QgsVectorLayer
+    _fields: list[QgsField] = [
+        QgsField("same-task", QVariant.Bool),
+        QgsField("from-waypoint-uuid", QVariant.String),
+        QgsField("to-waypoint-uuid", QVariant.String),
+    ]
+
+    def __init__(self, doc: 'MissionDocument', layerGroup: QgsLayerTreeGroup,
+                 color: QColor, parent: QObject | None = None):
+        super().__init__(parent)
+
+        self._doc = doc
+        self._setupLayer(layerGroup, color)
+        self.rebuildLayerFromMissionPlan(self._doc.plan)
+
+        self._doc.waypointAdded.connect(self.onWaypointAdded)
+        self._doc.beforeWaypointDeleted.connect(self.onBeforeWaypointDeleted)
+        self._doc.waypointChanged.connect(self.onWaypointChanged)
+
+        self._doc.taskAdded.connect(self.onTaskAdded)
+        self._doc.beforeTaskDeleted.connect(self.onBeforeTaskDeleted)
+
+    def _setupLayer(self, layerGroup: QgsLayerTreeGroup, color: QColor) -> None:
+        self._layer = QgsVectorLayer(
+            "LineString?crs=EPSG:4326",
+            "Tracks",
+            "memory",
+        )
+        self._layer.dataProvider().addAttributes(self._fields)
+        self._layer.updateFields()
+
+        # Make the layer non-removable (by users)
+        flags = self._layer.flags()
+        flags &= ~self._layer.LayerFlag.Removable
+        self._layer.setFlags(flags)
+
+        # Setup symbology for the layer
+        symbol = QgsSymbol.defaultSymbol(self._layer.geometryType())
+
+        # Default line symbol layer
+        lineSymbolLayer = symbol.symbolLayer(0)
+        lineSymbolLayer.setWidth(0.35)
+        # Same-task connections -> solid lines, otherwise dashed
+        lineSymbolLayer.setDataDefinedProperty(
+            QgsSimpleLineSymbolLayer.PropertyStrokeStyle,
+            QgsProperty.fromExpression(
+                "CASE WHEN \"same-task\" THEN 'solid' ELSE 'dash' END"
+            )
+        )
+        lineSymbolLayer.setColor(color)
+
+        # Arrow marker
+        markerLineSymbolLayer = QgsMarkerLineSymbolLayer()
+        markerLineSymbolLayer.setPlacements(Qgis.MarkerLinePlacement.SegmentCenter)
+        markerLineSymbolLayer.setRotateSymbols(True)
+
+        arrowSymbol = markerLineSymbolLayer.subSymbol()
+        arrowMarkerLayer = arrowSymbol.symbolLayer(0)
+
+        # Set the shape
+        arrowMarkerLayer.setShape(Qgis.MarkerShape.ArrowHeadFilled)
+        arrowMarkerLayer.setSize(3.0)
+        # No outline
+        arrowMarkerLayer.setStrokeStyle(Qt.NoPen)
+        arrowMarkerLayer.setColor(color)
+
+        symbol.appendSymbolLayer(markerLineSymbolLayer)
+        self._layer.setRenderer(QgsSingleSymbolRenderer(symbol))
+
+        # Distance labels
+        fmt = QgsTextFormat()
+        fmt.setSize(11)
+
+        settings = QgsVectorLayerSimpleLabeling.defaultSettingsForLayer(self._layer)
+        settings.fieldName = "format_number($length, 1) || ' m'"
+        settings.isExpression = True
+        settings.setFormat(fmt)
+
+        labeling = QgsVectorLayerSimpleLabeling(settings)
+        self._layer.setLabeling(labeling)
+        self._layer.setLabelsEnabled(True)
+
+        # Register the layer with QGIS and add it to the group
+        QgsProject.instance().addMapLayer(self._layer, False)
+        layerGroup.addLayer(self._layer)
+
+    def rebuildLayerFromMissionPlan(self, plan: MissionPlan) -> None:
+        # Drop all existing features
+        self._layer.dataProvider().truncate()
+
+        data = []
+        # Discover all the waypoints and their tasks
+        for task in plan.tasks:
+            for waypoint in iterTaskWaypoints(task):
+                data.append((waypoint, task.uuid))
+
+        # Build initial features
+        features = []
+        for i in range(len(data) - 1):
+            waypointFrom, taskFromUuid = data[i]
+            waypointTo, taskToUuid = data[i + 1]
+            sameTask = taskFromUuid == taskToUuid
+
+            feat = self.createLineFeature(waypointFrom, waypointTo, sameTask)
+            features.append(feat)
+
+        if features:
+            self._layer.dataProvider().addFeatures(features)
+
+    def createLineFeature(self, fromWaypoint: Waypoint, toWaypoint: Waypoint,
+                          sameTask: bool) -> QgsFeature:
+        fromPoint = QgsPointXY(fromWaypoint.longitude, fromWaypoint.latitude)
+        toPoint = QgsPointXY(toWaypoint.longitude, toWaypoint.latitude)
+        geom = QgsGeometry(QgsLineString([fromPoint, toPoint]))
+
+        feat = QgsFeature(self._layer.fields())
+        feat.setGeometry(geom)
+
+        attrs = {
+            "same-task": sameTask,
+            "from-waypoint-uuid": str(fromWaypoint.uuid),
+            "to-waypoint-uuid": str(toWaypoint.uuid),
+        }
+        for key, value in attrs.items():
+            feat.setAttribute(key, value)
+
+        return feat
+
+    def lineFeaturesForWaypointUuid(self, waypointUuid: UUID) \
+                                    -> tuple[QgsFeature | None, QgsFeature | None]:
+        featuresTo = self._layer.getFeatures(
+            f'"to-waypoint-uuid" = \'{waypointUuid}\''
+        )
+        featuresFrom = self._layer.getFeatures(
+            f'"from-waypoint-uuid" = \'{waypointUuid}\''
+        )
+
+        # TODO: check if >1 features for any UUID?
+        featTo = next(iter(featuresTo), None)
+        featFrom = next(iter(featuresFrom), None)
+
+        return featTo, featFrom
+
+    @pyqtSlot(UUID, str, UUID)
+    def onWaypointAdded(self, taskUuid: UUID, fieldName: str,
+                        waypointUuid: UUID) -> None:
+        waypoint = self._doc.index.waypointByUuid(waypointUuid)
+        if waypoint is None:
+            # TODO: invalid mapping
+            return
+
+        # Find the surrounding waypoints
+        prevWaypoint = self._doc.index.previousWaypointByUuid(waypointUuid)
+        nextWaypoint = self._doc.index.nextWaypointByUuid(waypointUuid)
+
+        if not any((prevWaypoint, nextWaypoint)):
+            # TODO: invalid mapping
+            return
+
+        updated = False
+        # Get rid of the existing segment between the surrounding waypoints
+        segment: QgsFeature | None
+        if prevWaypoint is not None:
+            _, segment = self.lineFeaturesForWaypointUuid(prevWaypoint.uuid)
+        else:
+            segment, _ = self.lineFeaturesForWaypointUuid(nextWaypoint.uuid)
+
+        if segment is not None:
+            self._layer.dataProvider().deleteFeatures([segment.id()])
+            updated = True
+
+        # Create the new segment(s)
+        features = []
+        if prevWaypoint is not None:
+            prevTaskUuid = self._doc.index.taskUuidByWaypointUuid(prevWaypoint.uuid)
+            sameTask = prevTaskUuid == taskUuid
+            feat = self.createLineFeature(prevWaypoint, waypoint, sameTask)
+            features.append(feat)
+
+        if nextWaypoint is not None:
+            nextTaskUuid = self._doc.index.taskUuidByWaypointUuid(nextWaypoint.uuid)
+            sameTask = taskUuid == nextTaskUuid
+
+            feat = self.createLineFeature(waypoint, nextWaypoint, sameTask)
+            features.append(feat)
+
+        if features:
+            self._layer.dataProvider().addFeatures(features)
+            updated = True
+
+        # Repaint the layer so changes are visible right away
+        if updated:
+            self._layer.updateExtents()
+            self._layer.triggerRepaint()
+
+    @pyqtSlot(UUID, str, UUID, int)
+    def onBeforeWaypointDeleted(self, taskUuid: UUID, fieldName: str,
+                                waypointUuid: UUID, index: int) -> None:
+        waypoint = self._doc.index.waypointByUuid(waypointUuid)
+        if waypoint is None:
+            # TODO: invalid mapping
+            return
+
+        # Find the surrounding waypoints
+        prevWaypoint = self._doc.index.previousWaypointByUuid(waypointUuid)
+        nextWaypoint = self._doc.index.nextWaypointByUuid(waypointUuid)
+
+        if not any((prevWaypoint, nextWaypoint)):
+            # TODO: invalid mapping
+            return
+
+        updated = False
+        # Get rid of the existing segments between the surrounding waypoints and this
+        # waypoint
+        featTo, featFrom = self.lineFeaturesForWaypointUuid(waypointUuid)
+        fidsToDelete = [feat.id() for feat in (featTo, featFrom) if feat]
+        if fidsToDelete:
+            self._layer.dataProvider().deleteFeatures(fidsToDelete)
+            updated = True
+
+        # Create the new segment, if needed
+        if all((prevWaypoint, nextWaypoint)):
+            prevTaskUuid = self._doc.index.taskUuidByWaypointUuid(prevWaypoint.uuid)
+            nextTaskUuid = self._doc.index.taskUuidByWaypointUuid(nextWaypoint.uuid)
+            sameTask = prevTaskUuid == nextTaskUuid
+
+            feat = self.createLineFeature(prevWaypoint, nextWaypoint, sameTask)
+            self._layer.dataProvider().addFeature(feat)
+            updated = True
+
+        # Repaint the layer so changes are visible right away
+        if updated:
+            self._layer.updateExtents()
+            self._layer.triggerRepaint()
+
+    @pyqtSlot(UUID)
+    def onWaypointChanged(self, waypointUuid: UUID) -> None:
+        # TODO: this gets called for parameter changes too, not only movement updates
+        waypoint = self._doc.index.waypointByUuid(waypointUuid)
+        if waypoint is None:
+            # TODO: invalid mapping
+            return
+
+        # Reuse existing segments, and update their termination points
+        featTo, featFrom = self.lineFeaturesForWaypointUuid(waypointUuid)
+
+        changes: dict[int, QgsGeometry] = {}
+        if featTo is not None:
+            geom = featTo.geometry()
+            geom.moveVertex(waypoint.longitude, waypoint.latitude, 1)
+            changes[featTo.id()] = geom
+
+        if featFrom is not None:
+            geom = featFrom.geometry()
+            geom.moveVertex(waypoint.longitude, waypoint.latitude, 0)
+            changes[featFrom.id()] = geom
+
+        if changes:
+            self._layer.dataProvider().changeGeometryValues(changes)
+            self._layer.updateExtents()
+            self._layer.triggerRepaint()
+
+    @pyqtSlot(UUID, int)
+    def onTaskAdded(self, taskUuid: UUID, row: int):
+        task = self._doc.index.taskByUuid(taskUuid)
+        if task is None:
+            # TODO: invalid mapping
+            return
+
+        waypoints = list(iterTaskWaypoints(task))
+        if len(waypoints) == 0:
+            # No waypoints on this task
+            return
+
+        prevTaskWaypoint = self._doc.index.previousWaypointByUuid(waypoints[0].uuid)
+        nextTaskWaypoint = self._doc.index.nextWaypointByUuid(waypoints[-1].uuid)
+
+        # If both previous and next task waypoints exist, there must currently be a
+        # single segment between them. We need to get rid of it.
+        segment: QgsFeature | None = None
+        if prevTaskWaypoint is not None:
+            _, segment = self.lineFeaturesForWaypointUuid(prevTaskWaypoint.uuid)
+        elif nextTaskWaypoint is not None:
+            segment, _ = self.lineFeaturesForWaypointUuid(nextTaskWaypoint.uuid)
+
+        updated = False
+        if segment is not None:
+            self._layer.dataProvider().deleteFeatures([segment.id()])
+            updated = True
+
+        # Collect all the segments
+        features: list[QgsFeature] = []
+
+        # Add a segment from the previous task to this one, if needed
+        if prevTaskWaypoint is not None:
+            feat = self.createLineFeature(prevTaskWaypoint, waypoints[0], False)
+            features.append(feat)
+
+        # Build segments inside the task
+        thisWaypoint = waypoints[0]
+        finalWaypoint = waypoints[-1]
+        while thisWaypoint.uuid != finalWaypoint.uuid:
+            nextWaypoint = self._doc.index.nextWaypointByUuid(thisWaypoint.uuid)
+
+            # All segments here are part of the same task, by definition
+            feat = self.createLineFeature(thisWaypoint, nextWaypoint, True)
+            features.append(feat)
+
+            thisWaypoint = nextWaypoint
+
+        # Add a segment from this task to the next one, if needed
+        if nextTaskWaypoint is not None:
+            feat = self.createLineFeature(waypoints[-1], nextTaskWaypoint, False)
+            features.append(feat)
+
+        # No features is possible if this is the first task in the mission plan, and it
+        # only has a single waypoint
+        if features:
+            self._layer.dataProvider().addFeatures(features)
+            updated = True
+
+        if updated:
+            self._layer.updateExtents()
+            self._layer.triggerRepaint()
+
+    @pyqtSlot(UUID)
+    def onBeforeTaskDeleted(self, taskUuid: UUID) -> None:
+        task = self._doc.index.taskByUuid(taskUuid)
+        if task is None:
+            # TODO: invalid mapping
+            return
+
+        waypoints = list(iterTaskWaypoints(task))
+        if len(waypoints) == 0:
+            # No waypoints on this task
+            return
+
+        prevTaskWaypoint = self._doc.index.previousWaypointByUuid(waypoints[0].uuid)
+        nextTaskWaypoint = self._doc.index.nextWaypointByUuid(waypoints[-1].uuid)
+
+        thisWaypoint = prevTaskWaypoint or waypoints[0]
+        finalWaypoint = nextTaskWaypoint or waypoints[-1]
+
+        # Collect feature IDs of segments to remove
+        fids: list[int] = []
+        while thisWaypoint.uuid != finalWaypoint.uuid:
+            # Take the "from" segment for each waypoint
+            _, feat = self.lineFeaturesForWaypointUuid(thisWaypoint.uuid)
+            fids.append(feat.id())
+            thisWaypoint = self._doc.index.nextWaypointByUuid(thisWaypoint.uuid)
+
+        updated = False
+        # No features is possible if this is the last task with waypoints in the
+        # mission plan, and it only has the one waypoint.
+        if fids:
+            self._layer.dataProvider().deleteFeatures(fids)
+            updated = True
+
+        if prevTaskWaypoint and nextTaskWaypoint:
+            # Create a new segment between the neighboring tasks.
+            # Previous and next waypoints are not from the same task by definition.
+            feat = self.createLineFeature(prevTaskWaypoint, nextTaskWaypoint, False)
+            self._layer.dataProvider().addFeature(feat)
+            updated = True
+
+        if updated:
+            self._layer.updateExtents()
+            self._layer.triggerRepaint()

--- a/src/ui/widgets/MissionPlanWidget.py
+++ b/src/ui/widgets/MissionPlanWidget.py
@@ -49,14 +49,8 @@ class MissionPlanWidget(QWidget):
         self._missionContext.editingAboutToFinish.connect(self.onEditingAboutToFinish)
 
         # Signals for refreshing the task list
-        # TODO
-        def resetTaskList():
-            self.taskListModel.beginResetModel()
-            self.taskListModel.endResetModel()
-            self.onTaskSelectionChanged(None, None)
-
-        self._missionContext.taskListModified.connect(resetTaskList)
         self._missionContext.taskAdded.connect(self.onTaskAdded)
+        self._missionContext.taskDeleted.connect(self.onTaskDeleted)
 
         # Setup icons for the task buttons
         self.ui.buttonAddTask.setIcon(QgsApplication.getThemeIcon("symbologyAdd.svg"))
@@ -177,11 +171,31 @@ class MissionPlanWidget(QWidget):
             index = rows[0].row()
             doc.deleteTaskAt(index)
 
+    def _resetTaskList(self):
+        self.taskListModel.beginResetModel()
+        self.taskListModel.endResetModel()
+        self.onTaskSelectionChanged(None, None)
+
     @pyqtSlot(UUID, int)
     def onTaskAdded(self, taskUuid: UUID, row: int):
+        # TODO: be more smart about updating the task list
+        self._resetTaskList()
+
+        # Select the newly added task
         index = self.taskListModel.index(row, 0)
         self.ui.taskList.setCurrentIndex(index)
         self.ui.taskList.scrollTo(index)
+
+    def onTaskDeleted(self, taskUuid: UUID, row: int):
+        # TODO: be more smart about updating the task list
+        self._resetTaskList()
+
+        # Select the next task, or the last one
+        row = min(self.taskListModel.rowCount() - 1, row)
+        if row >= 0:
+            index = self.taskListModel.index(row, 0)
+            self.ui.taskList.setCurrentIndex(index)
+            self.ui.taskList.scrollTo(index)
 
     def activateEditorForTask(self, task):
         if task is None:


### PR DESCRIPTION
This set of changes implements a tracks layer, for showing line segments between waypoints. Tracks between waypoints in the same task use a solid line, while tracks between different tasks use a dotted line. The tracks also display distance labels.

The layer organization has been changed somewhat. Previously, we had
```
SMaRCMissionWaypoints
├── SMaRCMissionWaypoints<MissionPlan-UUID-1>
├── SMaRCMissionWaypoints<MissionPlan-UUID-2>
└── ...
```

Now, each mission gets its own group, where the layers for waypoints and tracks are located:
```
SMaRCMissions
├── <MissionPlan-UUID-1>
│   ├── Waypoints
│   └── Tracks
├── <MissionPlan-UUID-2>
│   ├── Waypoints
│   └── Tracks
└── ...
```

In the future, a layer for polygons could be added to each group as well.

Additionally, selecting a mission plan will now select the corresponding waypoints layer, hopefully alleviating some confusion about which layer is being edited/where is the undo stack at.

Closes #74 