### PR TITLE
Rework highlighting of map items

### DIFF
--- a/src/mission/MissionContext.py
+++ b/src/mission/MissionContext.py
@@ -10,6 +10,7 @@ from .MissionMapManager import MissionMapManager
 from .MissionDocument import MissionDocument
 from ..domain.missionplan import MissionPlan
 from ..domain.tasks import PendingWaypointTask
+from ..domain.taskspatial import iterTaskWaypoints
 
 
 __all__ = ["MissionContext"]
@@ -96,6 +97,7 @@ class MissionContext(QObject):
 
     @pyqtSlot(UUID)
     def changeActiveMission(self, planUuid: UUID):
+        # Disconnect signals from the old document, connect to the new document
         doc = self.activeDocument()
         if doc is not None:
             self._unbindDocument(doc)
@@ -110,11 +112,39 @@ class MissionContext(QObject):
         # Activate the corresponding waypoint layer
         iface.setActiveLayer(doc.layerBridge.waypointLayer)
 
+        # Inform the layers of their changed activity status
+        for otherUuid, otherDoc in self._missionDocuments.items():
+            active = otherUuid == planUuid
+            otherDoc.layerBridge.setActive(active)
+            otherDoc.layerBridge.tracks.setActive(otherUuid == planUuid)
+
         self.activeMissionChanged.emit(doc)
 
         # Ensure good state for widgets
         self.editingFinished.emit()
         self.editModeChanged.emit(False)
+
+    @pyqtSlot(list)
+    def onTaskSelectionChanged(self, taskUuids: list[UUID]) -> None:
+        doc = self.activeDocument()
+        if doc is None:
+            return
+
+        tasks = [doc.index.taskByUuid(taskUuid) for taskUuid in taskUuids]
+        nestedWaypoints = [list(iterTaskWaypoints(task)) for task in tasks if task]
+        waypoints = sum(nestedWaypoints, [])
+
+        iface.mapCanvas().expressionContextScope().setVariable(
+            "selected_task_uuids",
+            [str(taskUuid) for taskUuid in taskUuids]
+        )
+        iface.mapCanvas().expressionContextScope().setVariable(
+            "selected_task_waypoint_uuids",
+            [str(waypoint.uuid) for waypoint in waypoints]
+        )
+
+        doc.layerBridge.waypointLayer.triggerRepaint()
+        doc.layerBridge.tracks._layer.triggerRepaint()
 
     @pyqtSlot(PendingWaypointTask, QgsPointXY)
     # TODO: should this be here?

--- a/src/mission/MissionLayerBridge.py
+++ b/src/mission/MissionLayerBridge.py
@@ -3,7 +3,10 @@ from dataclasses import dataclass
 from contextlib import contextmanager
 
 from qgis.PyQt.QtCore import pyqtSlot, pyqtSignal, QObject, QVariant
-from qgis.core import QgsProject, QgsField, QgsFeature, QgsVectorLayer, QgsGeometry, QgsPointXY, QgsLayerTreeGroup
+from qgis.PyQt.QtGui import QColor
+from qgis.core import QgsProject, QgsField, QgsFeature, QgsVectorLayer, QgsGeometry, \
+    QgsPointXY, QgsLayerTreeGroup, QgsProperty, QgsSymbol, QgsSimpleMarkerSymbolLayer, \
+    QgsSingleSymbolRenderer, QgsFeatureRenderer
 
 from ..compat import StrEnum, assert_never
 from ..domain.missionplan import MissionPlan
@@ -44,6 +47,10 @@ class MissionLayerBridge(QObject):
         REPLAYING_QGIS_COMMAND = 'replaying-qgis-command'
 
     SMARC_GROUP_NAME = 'SMaRCMissions'
+    # TODO: centralized place for these
+    COLOR_SELECTED_TASK = QColor("#D81B60")
+    COLOR_INACTIVE = QColor("#666666")
+    COLOR_ACTIVE = QColor("#7040A0")
 
     waypointMoved = pyqtSignal(UUID, QgsPointXY)
     waypointAdded = pyqtSignal(UUID, UUID, QgsPointXY)
@@ -90,6 +97,53 @@ class MissionLayerBridge(QObject):
 
         self._layerGroup = layerGroup
 
+    def _createActiveRenderer(self) -> QgsFeatureRenderer:
+        # Configure symbol for layer
+        symbol = QgsSymbol.defaultSymbol(self.waypointLayer.geometryType())
+
+        markerSymbolLayer = symbol.symbolLayer(0)
+        markerSymbolLayer.setColor(self.COLOR_ACTIVE)
+        markerSymbolLayer.setDataDefinedProperty(
+            QgsSimpleMarkerSymbolLayer.PropertyFillColor,
+            QgsProperty.fromExpression(f'''
+                CASE WHEN
+                    array_contains(@selected_task_uuids, "task-uuid")
+                THEN '{self.COLOR_SELECTED_TASK.name()}'
+                ELSE '{markerSymbolLayer.color().name()}' END
+            ''')
+        )
+        markerSymbolLayer.setSize(2.0)
+        markerSymbolLayer.setDataDefinedProperty(
+            QgsSimpleMarkerSymbolLayer.PropertySize,
+            QgsProperty.fromExpression(f'''
+                CASE WHEN
+                    array_contains(@selected_task_uuids, "task-uuid")
+                THEN 3
+                ELSE {markerSymbolLayer.size()} END
+            ''')
+        )
+
+        return QgsSingleSymbolRenderer(symbol)
+
+    def _createInactiveRenderer(self) -> QgsFeatureRenderer:
+        # Configure symbol for layer
+        symbol = QgsSymbol.defaultSymbol(self.waypointLayer.geometryType())
+
+        markerSymbolLayer = symbol.symbolLayer(0)
+        markerSymbolLayer.setColor(self.COLOR_INACTIVE)
+        markerSymbolLayer.setSize(2.0)
+
+        return QgsSingleSymbolRenderer(symbol)
+
+    def setActive(self, active: bool = True) -> None:
+        opacity = 1.0 if active else 0.4
+        self.waypointLayer.setOpacity(opacity)
+
+        renderer = self._activeRenderer if active else self._inactiveRenderer
+        # Need to clone the reusable renderer, since layer takes ownership of it
+        self.waypointLayer.setRenderer(renderer.clone())
+        self.waypointLayer.triggerRepaint()
+
     def _initializeLayers(self, planUuid: UUID) -> None:
         """
         Important: The default layer CRS for waypoint layers is set to EPSG:4326.
@@ -97,6 +151,7 @@ class MissionLayerBridge(QObject):
         This default is dictated by the vehicles. No reprojection of coordinates 
         needed as long as waypoint layer is initialized with EPSG:4326.
         """
+        # TODO: Split this into a separate class like MissionTracks
 
         # Setup waypoint layer
         self.waypointLayer = QgsVectorLayer(
@@ -105,8 +160,8 @@ class MissionLayerBridge(QObject):
             'memory'
         )
         self.waypointLayer.dataProvider().addAttributes([
-            QgsField('task-uuid', QVariant.String),
             QgsField('waypoint-uuid', QVariant.String),
+            QgsField('task-uuid', QVariant.String),
             QgsField('tolerance', QVariant.Double)
         ])
         self.waypointLayer.updateFields()
@@ -115,6 +170,9 @@ class MissionLayerBridge(QObject):
         flags = self.waypointLayer.flags()
         flags &= ~self.waypointLayer.LayerFlag.Removable
         self.waypointLayer.setFlags(flags)
+
+        self._activeRenderer = self._createActiveRenderer()
+        self._inactiveRenderer = self._createInactiveRenderer()
 
         # Register the layer with QGIS and add it to the group
         QgsProject().instance().addMapLayer(self.waypointLayer, False)
@@ -131,9 +189,7 @@ class MissionLayerBridge(QObject):
         self.waypointLayer.editCommandEnded.connect(self.onEditCommandEnded)
 
         # Setup the tracks layer
-        # Use same color as the waypoint layer
-        color = self.waypointLayer.renderer().symbol().color()
-        self.tracks = MissionTracks(self.parent(), self._layerGroup, color, self)
+        self.tracks = MissionTracks(self.parent(), self._layerGroup, self)
 
     def _populateLayers(self, plan: MissionPlan) -> None:
         for task in plan.tasks:

--- a/src/mission/MissionTracks.py
+++ b/src/mission/MissionTracks.py
@@ -15,18 +15,25 @@ __all__ = ["MissionTracks"]
 class MissionTracks(QObject):
     _doc: 'MissionDocument'
     _layer: QgsVectorLayer
+    _activeRenderer: QgsFeatureRenderer
+    _inactiveRenderer: QgsFeatureRenderer
     _fields: list[QgsField] = [
         QgsField("same-task", QVariant.Bool),
         QgsField("from-waypoint-uuid", QVariant.String),
         QgsField("to-waypoint-uuid", QVariant.String),
     ]
 
+    LABEL_BACKGROUND_OPACITY: float = 0.7
+    COLOR_SELECTED_TASK = QColor("#D81B60")
+    COLOR_INACTIVE = QColor("#666666")
+    COLOR_ACTIVE = QColor("#7040A0")
+
     def __init__(self, doc: 'MissionDocument', layerGroup: QgsLayerTreeGroup,
-                 color: QColor, parent: QObject | None = None):
+                 parent: QObject | None = None):
         super().__init__(parent)
 
         self._doc = doc
-        self._setupLayer(layerGroup, color)
+        self._setupLayer(layerGroup)
         self.rebuildLayerFromMissionPlan(self._doc.plan)
 
         self._doc.waypointAdded.connect(self.onWaypointAdded)
@@ -36,7 +43,119 @@ class MissionTracks(QObject):
         self._doc.taskAdded.connect(self.onTaskAdded)
         self._doc.beforeTaskDeleted.connect(self.onBeforeTaskDeleted)
 
-    def _setupLayer(self, layerGroup: QgsLayerTreeGroup, color: QColor) -> None:
+    def _createActiveRenderer(self) -> QgsFeatureRenderer:
+        # Setup symbology for the layer
+        symbol = QgsSymbol.defaultSymbol(self._layer.geometryType())
+
+        # Default line symbol layer
+        lineSymbolLayer = symbol.symbolLayer(0)
+        # Same-task connections -> solid lines, otherwise dashed
+        lineSymbolLayer.setColor(self.COLOR_ACTIVE)
+        lineSymbolLayer.setDataDefinedProperty(
+            QgsSimpleLineSymbolLayer.PropertyStrokeStyle,
+            QgsProperty.fromExpression(
+                "CASE WHEN \"same-task\" THEN 'solid' ELSE 'dash' END"
+            )
+        )
+        lineSymbolLayer.setDataDefinedProperty(
+            QgsSimpleMarkerSymbolLayer.PropertyStrokeColor,
+            QgsProperty.fromExpression(f'''
+                CASE WHEN
+                    array_contains(@selected_task_waypoint_uuids, "from-waypoint-uuid")
+                    AND array_contains(@selected_task_waypoint_uuids, "to-waypoint-uuid")
+                THEN '{self.COLOR_SELECTED_TASK.name()}'
+                ELSE '{lineSymbolLayer.color().name()}'
+                END
+            ''')
+        )
+        lineSymbolLayer.setDataDefinedProperty(
+            QgsSimpleMarkerSymbolLayer.PropertyStrokeWidth,
+            QgsProperty.fromExpression(
+                '''
+                CASE WHEN
+                    array_contains(@selected_task_waypoint_uuids, "from-waypoint-uuid")
+                    AND array_contains(@selected_task_waypoint_uuids, "to-waypoint-uuid")
+                THEN 1
+                ELSE 0.45
+                END'''
+            )
+        )
+
+        # Arrow marker
+        markerLineSymbolLayer = QgsMarkerLineSymbolLayer()
+        markerLineSymbolLayer.setPlacements(Qgis.MarkerLinePlacement.SegmentCenter)
+        markerLineSymbolLayer.setRotateSymbols(True)
+
+        arrowSymbol = markerLineSymbolLayer.subSymbol()
+        arrowMarkerLayer = arrowSymbol.symbolLayer(0)
+
+        # No outline
+        arrowMarkerLayer.setStrokeStyle(Qt.NoPen)
+        arrowMarkerLayer.setColor(self.COLOR_ACTIVE)
+        # Set the shape
+        arrowMarkerLayer.setShape(Qgis.MarkerShape.ArrowHeadFilled)
+        arrowMarkerLayer.setDataDefinedProperty(
+            QgsSimpleMarkerSymbolLayer.PropertySize,
+            QgsProperty.fromExpression('''
+                CASE WHEN
+                    array_contains(@selected_task_waypoint_uuids, "from-waypoint-uuid")
+                    AND array_contains(@selected_task_waypoint_uuids, "to-waypoint-uuid")
+                THEN 5
+                ELSE 3 END
+            ''')
+        )
+        arrowMarkerLayer.setDataDefinedProperty(
+            QgsSimpleMarkerSymbolLayer.PropertyFillColor,
+            QgsProperty.fromExpression(f'''
+                CASE WHEN
+                    array_contains(@selected_task_waypoint_uuids, "from-waypoint-uuid")
+                    AND array_contains(@selected_task_waypoint_uuids, "to-waypoint-uuid")
+                THEN '{self.COLOR_SELECTED_TASK.name()}'
+                ELSE '{arrowMarkerLayer.color().name()}'
+                END
+            ''')
+        )
+
+        symbol.appendSymbolLayer(markerLineSymbolLayer)
+
+        return QgsSingleSymbolRenderer(symbol)
+
+    def _createInactiveRenderer(self) -> QgsFeatureRenderer:
+        # Setup symbology for the layer
+        symbol = QgsSymbol.defaultSymbol(self._layer.geometryType())
+
+        # Default line symbol layer
+        lineSymbolLayer = symbol.symbolLayer(0)
+        lineSymbolLayer.setColor(self.COLOR_INACTIVE)
+        lineSymbolLayer.setWidth(0.45)
+        # Same-task connections -> solid lines, otherwise dashed
+        lineSymbolLayer.setDataDefinedProperty(
+            QgsSimpleLineSymbolLayer.PropertyStrokeStyle,
+            QgsProperty.fromExpression(
+                "CASE WHEN \"same-task\" THEN 'solid' ELSE 'dash' END"
+            )
+        )
+
+        # Arrow marker
+        markerLineSymbolLayer = QgsMarkerLineSymbolLayer()
+        markerLineSymbolLayer.setPlacements(Qgis.MarkerLinePlacement.SegmentCenter)
+        markerLineSymbolLayer.setRotateSymbols(True)
+
+        arrowSymbol = markerLineSymbolLayer.subSymbol()
+        arrowMarkerLayer = arrowSymbol.symbolLayer(0)
+
+        # No outline
+        arrowMarkerLayer.setStrokeStyle(Qt.NoPen)
+
+        arrowMarkerLayer.setColor(self.COLOR_INACTIVE)
+        arrowMarkerLayer.setShape(Qgis.MarkerShape.ArrowHeadFilled)
+        arrowMarkerLayer.setSize(3.0)
+
+        symbol.appendSymbolLayer(markerLineSymbolLayer)
+
+        return QgsSingleSymbolRenderer(symbol)
+
+    def _setupLayer(self, layerGroup: QgsLayerTreeGroup) -> None:
         self._layer = QgsVectorLayer(
             "LineString?crs=EPSG:4326",
             "Tracks",
@@ -50,44 +169,15 @@ class MissionTracks(QObject):
         flags &= ~self._layer.LayerFlag.Removable
         self._layer.setFlags(flags)
 
-        # Setup symbology for the layer
-        symbol = QgsSymbol.defaultSymbol(self._layer.geometryType())
-
-        # Default line symbol layer
-        lineSymbolLayer = symbol.symbolLayer(0)
-        lineSymbolLayer.setWidth(0.35)
-        # Same-task connections -> solid lines, otherwise dashed
-        lineSymbolLayer.setDataDefinedProperty(
-            QgsSimpleLineSymbolLayer.PropertyStrokeStyle,
-            QgsProperty.fromExpression(
-                "CASE WHEN \"same-task\" THEN 'solid' ELSE 'dash' END"
-            )
-        )
-        lineSymbolLayer.setColor(color)
-
-        # Arrow marker
-        markerLineSymbolLayer = QgsMarkerLineSymbolLayer()
-        markerLineSymbolLayer.setPlacements(Qgis.MarkerLinePlacement.SegmentCenter)
-        markerLineSymbolLayer.setRotateSymbols(True)
-
-        arrowSymbol = markerLineSymbolLayer.subSymbol()
-        arrowMarkerLayer = arrowSymbol.symbolLayer(0)
-
-        # Set the shape
-        arrowMarkerLayer.setShape(Qgis.MarkerShape.ArrowHeadFilled)
-        arrowMarkerLayer.setSize(3.0)
-        # No outline
-        arrowMarkerLayer.setStrokeStyle(Qt.NoPen)
-        arrowMarkerLayer.setColor(color)
-
-        symbol.appendSymbolLayer(markerLineSymbolLayer)
-        self._layer.setRenderer(QgsSingleSymbolRenderer(symbol))
+        # Create renderers for both states
+        self._activeRenderer = self._createActiveRenderer()
+        self._inactiveRenderer = self._createInactiveRenderer()
 
         # Set label background
         bg = QgsTextBackgroundSettings()
         bg.setEnabled(True)
         bg.setFillColor(QColor("white"))
-        bg.setOpacity(0.7)
+        bg.setOpacity(self.LABEL_BACKGROUND_OPACITY)
         current_bg_size = bg.size()
         bg.setSize(QSizeF(current_bg_size.width() + 0.5, current_bg_size.height()))
         
@@ -103,11 +193,27 @@ class MissionTracks(QObject):
 
         labeling = QgsVectorLayerSimpleLabeling(settings)
         self._layer.setLabeling(labeling)
-        self._layer.setLabelsEnabled(True)
+
+        # Make the layer use the proper renderer and labeling
+        self.setActive(True)
 
         # Register the layer with QGIS and add it to the group
         QgsProject.instance().addMapLayer(self._layer, False)
         layerGroup.addLayer(self._layer)
+
+    def setActive(self, active: bool = True) -> None:
+        opacity = 1.0 if active else 0.4
+        # Layer itself
+        self._layer.setOpacity(opacity)
+
+        # Labeling
+        self._layer.setLabelsEnabled(active)
+
+        # Renderer
+        renderer = self._activeRenderer if active else self._inactiveRenderer
+        # Need to clone the reusable renderer, since layer takes ownership of it
+        self._layer.setRenderer(renderer.clone())
+        self._layer.triggerRepaint()
 
     def rebuildLayerFromMissionPlan(self, plan: MissionPlan) -> None:
         # Drop all existing features

--- a/src/mission/MissionTracks.py
+++ b/src/mission/MissionTracks.py
@@ -18,9 +18,9 @@ class MissionTracks(QObject):
     _activeRenderer: QgsFeatureRenderer
     _inactiveRenderer: QgsFeatureRenderer
     _fields: list[QgsField] = [
-        QgsField("same-task", QVariant.Bool),
         QgsField("from-waypoint-uuid", QVariant.String),
         QgsField("to-waypoint-uuid", QVariant.String),
+        QgsField("same-task", QVariant.Bool),
     ]
 
     LABEL_BACKGROUND_OPACITY: float = 0.7

--- a/src/ui/widgets/MissionControlDockWidget.py
+++ b/src/ui/widgets/MissionControlDockWidget.py
@@ -36,6 +36,9 @@ class MissionControlDockWidget(QgsDockWidget):
             self._missionContext,
             self.ui.tabWidget
         )
+        self.ui.tabMissionPlan.taskSelectionChanged.connect(
+            self._missionContext.onTaskSelectionChanged
+        )
         self.ui.tabWidget.addTab(self.ui.tabMissionPlan, "")
 
         self.ui.tabFleetControl = FleetControlWidget(

--- a/src/ui/widgets/MissionPlanWidget.py
+++ b/src/ui/widgets/MissionPlanWidget.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from qgis.PyQt.QtCore import Qt, pyqtSlot, QItemSelection
+from qgis.PyQt.QtCore import Qt, pyqtSignal, pyqtSlot, QItemSelection
 from qgis.PyQt.QtWidgets import (QWidget, QHeaderView, QAbstractItemDelegate, QDialog,
                                  QDataWidgetMapper, QMessageBox)
 from qgis.core import QgsApplication
@@ -20,6 +20,8 @@ class MissionPlanWidget(QWidget):
     taskEditors: dict[str, TaskEditorWidget]
 
     _missionContext: MissionContext
+
+    taskSelectionChanged = pyqtSignal(list)
 
     def __init__(self, missionContext: MissionContext,
                  parent: QWidget | None = None) -> None:
@@ -137,6 +139,9 @@ class MissionPlanWidget(QWidget):
         else:
             task = self.taskListModel.item(rows[0].row())
             self.activateEditorForTask(task)
+
+        taskUuids = [self.taskListModel.item(row.row()).uuid for row in rows]
+        self.taskSelectionChanged.emit(taskUuids)
 
     @pyqtSlot()
     def onAddTaskClicked(self):


### PR DESCRIPTION
This PR reworks how mission plans are rendered. Instead of each one having a separate color, there are now three pre-defined colors:

- Active mission plan
- Inactive mission plan
- Selected task within active mission plan

When a mission plan is selected in the mission plan dropdown list, it becomes active. Its color is changed to the _active_ color, while all the other mission plans are rendered _inactive_. Furthermore, their opacity is reduced, and their distance labels no longer render.

When one or more tasks are selected in the task list, their waypoints -- if any -- and tracks between them will become highlighted with the _selected_ color. Furthermore, their size/width is increased to make it easier to distinguish them from the other waypoints in the mission.

## Limitations
The selection only works one way -- from the UI to the map. There is a built-in QGIS tool to select features the map. It can be used, and it will highlight the selected waypoints a vibrant yellow, but this selection does _not_ currently propagate to the mission planning UI.

There is also a separate tool available in edit mode, which allows to select waypoints and move them around. This tool is separate from the aforementioned feature selection, but does have some interplay with it. I'd say we need a separate issue/discussion to figure out how to best integrate with these existing QGIS tools, if at all.

Closes #73 