### PR TITLE
Clean up imports and add Ruff checks

### DIFF
--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -1,0 +1,31 @@
+name: Import checks
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  ruff:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Check out plugin repo
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
+        with:
+          version: "0.11.26"
+
+      - name: Install dependencies
+        run: uv sync --locked
+
+      - name: Check imports
+        run: uv run --no-sync ruff check src/

--- a/README.md
+++ b/README.md
@@ -38,6 +38,42 @@ Supported Ubuntu version(s): 22.04 (Python 3.10)
 
 ## Developer instructions
 
+### Development setup
+1. Install [uv](https://docs.astral.sh/uv/getting-started/installation/).
+2. Install the development dependencies from the repository root:
+
+```bash
+uv sync
+```
+
+On Linux, if QGIS/PyQGIS is installed system-wide and you want it available inside the environment for tools such as mypy, create the environment with:
+
+```bash
+uv venv --system-site-packages
+uv sync
+```
+
+3. Check imports before pushing changes:
+
+```bash
+uv run ruff check src/
+```
+
+Most import issues can be fixed automatically with:
+
+```bash
+uv run ruff check --fix src/
+```
+
+Import checks are also run automatically on pull requests targeting `master`. Pull requests should pass these checks before they can be merged.
+
+The import checks currently cover:
+
+- No wildcard (`*`) imports
+- No unused imports
+- No undefined names
+- Consistent import ordering
+
 ### UI design
 0. Install PyQt5 via `pip install PyQt5` (or any other way)
 1. Develop UI layout in QtDesigner to generate *.ui files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,67 @@
+[project]
+name = "smarc_qgis_mission_control"
+version = "0.0.0"
+requires-python = "==3.10.*"
+
+[tool.mypy]
+python_version = "3.10"
+pretty = true
+warn_return_any = true
+exclude = [
+    "^src/ui/generated/",
+    "^src/third_party/",
+]
+
+# PyQt through QGIS
+[[tool.mypy.overrides]]
+module = ["qgis.PyQt.*"]
+follow_untyped_imports = true
+
+# TODO: ignore paho for now
+[[tool.mypy.overrides]]
+module = ["paho", "paho.*"]
+ignore_missing_imports = true
+
+[tool.ruff]
+extend-exclude = [
+    "src/ui/generated/",
+    "src/third_party/",
+]
+force-exclude = true
+line-length = 88
+
+[tool.ruff.lint]
+select = [
+    # Multiple imports on one line
+    "E401",
+    # Module imported but unused
+    "F401",
+    # Star imports
+    "F403",
+    # Name is undefined, or comes from star imports
+    "F405",
+    # Undefined name
+    "F821",
+    # Unsorted imports
+    "I001",
+]
+
+[tool.ruff.lint.isort]
+section-order = [
+    "future",
+    "standard-library",
+    "third-party",
+    "qt",
+    "first-party",
+    "local-folder",
+]
+
+[tool.ruff.lint.isort.sections]
+qt = ["qgis.PyQt", "qgis.PyQt.*"]
+
+[dependency-groups]
+dev = [
+    "mypy>=2.3.0",
+    "qgis-stubs>=0.4.0",
+    "ruff>=0.16.1",
+]

--- a/src/compat.py
+++ b/src/compat.py
@@ -1,6 +1,5 @@
-from typing import NoReturn
 from enum import Enum
-
+from typing import NoReturn
 
 __all__ = ["StrEnum"]
 

--- a/src/context/FleetContext.py
+++ b/src/context/FleetContext.py
@@ -1,13 +1,9 @@
-from qgis.PyQt import uic
-from qgis.PyQt.QtCore import *
-from qgis.PyQt.QtGui import *
-from qgis.PyQt.QtWidgets import *
-from qgis.gui import *
-from qgis.core import *
+from qgis.PyQt.QtCore import QObject
 
-from .MqttService import MqttService
-from .FleetState import FleetState
 from .FleetMapManager import FleetMapManager
+from .FleetState import FleetState
+from .MqttService import MqttService
+
 
 class FleetContext(QObject):
     def __init__(self, parent: QObject | None = None):

--- a/src/context/FleetMapManager.py
+++ b/src/context/FleetMapManager.py
@@ -1,14 +1,28 @@
 from dataclasses import dataclass
 
-from qgis.PyQt.QtCore import QObject, pyqtSlot, pyqtSignal, QVariant
-from qgis.PyQt.QtGui import QColor
-from qgis.core import QgsProject, QgsVectorLayer, QgsFeature, QgsGeometry, QgsField, \
-    QgsPointXY, QgsCategorizedSymbolRenderer, QgsSymbol, QgsUnitTypes, QgsProperty, \
-    QgsRendererCategory, QgsMarkerSymbol, QgsSymbolLayer, QgsSvgMarkerSymbolLayer
+from qgis.core import (
+    QgsCategorizedSymbolRenderer,
+    QgsFeature,
+    QgsField,
+    QgsGeometry,
+    QgsMarkerSymbol,
+    QgsPointXY,
+    QgsProject,
+    QgsProperty,
+    QgsRendererCategory,
+    QgsSvgMarkerSymbolLayer,
+    QgsSymbol,
+    QgsSymbolLayer,
+    QgsUnitTypes,
+    QgsVectorLayer,
+)
 from qgis.gui import QgsRubberBand
 from qgis.utils import iface
 
-from .FleetState import *
+from qgis.PyQt.QtCore import QObject, QVariant, pyqtSignal, pyqtSlot
+from qgis.PyQt.QtGui import QColor
+
+from .FleetState import FleetState
 
 
 @dataclass

--- a/src/context/FleetState.py
+++ b/src/context/FleetState.py
@@ -1,15 +1,18 @@
 from dataclasses import dataclass, field
 
-from qgis.PyQt.QtCore import QObject, pyqtSlot, pyqtSignal, QVariant
-from qgis.PyQt.QtGui import QColor
-from qgis.core import QgsProject, QgsVectorLayer, QgsFeature, QgsGeometry, QgsField, \
-    QgsPointXY, QgsCategorizedSymbolRenderer, QgsApplication, QgsSymbol, \
-    QgsRendererCategory, QgsApplication
-from qgis.gui import QgsRubberBand
-from qgis.utils import iface
+from qgis.core import QgsApplication
 
-from .MqttService import MqttService, VehicleHeartbeatEvent, VehicleSensorEvent, VehicleTaskStateEvent
+from qgis.PyQt.QtCore import QObject, pyqtSignal, pyqtSlot
+from qgis.PyQt.QtGui import QColor
+
 from ..domain.waraps import WaraPsExecutingTask
+from .MqttService import (
+    MqttService,
+    VehicleHeartbeatEvent,
+    VehicleSensorEvent,
+    VehicleTaskStateEvent,
+)
+
 
 @dataclass
 class VehicleState:

--- a/src/context/MqttService.py
+++ b/src/context/MqttService.py
@@ -1,23 +1,24 @@
-import re
 import json
-import threading
+import os
+import re
 import socket
-from uuid import UUID, uuid4
-from dataclasses import dataclass
+import sys
+import threading
 from copy import deepcopy
+from dataclasses import dataclass
+from uuid import UUID, uuid4
 
-from qgis.PyQt.QtCore import QObject, pyqtSlot, pyqtSignal
+from qgis.PyQt.QtCore import QObject, pyqtSignal, pyqtSlot
 
 # Import bundled MQTT
-import os, sys
 path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'third_party')
 sys.path.insert(0, path)
 import paho.mqtt.client as mqtt
 
 from ..compat import StrEnum
-from ..domain.waraps import *
-from ..domain.waypoints import GeoPoint
 from ..domain.missionplan import MissionPlan
+from ..domain.waraps import WaraPsAvailableTask, WaraPsExecutingTask
+from ..domain.waypoints import GeoPoint
 
 
 @dataclass

--- a/src/domain/jsoncodec.py
+++ b/src/domain/jsoncodec.py
@@ -1,7 +1,7 @@
 from enum import Enum
-from typing import Any, get_origin, get_args
+from typing import Any, get_args, get_origin
 
-from .schema import FieldSpec, SchemaMixin
+from .schema import SchemaMixin
 
 
 class JsonCodec:

--- a/src/domain/missionplan.py
+++ b/src/domain/missionplan.py
@@ -1,9 +1,9 @@
-from typing import Any, Annotated
 from dataclasses import dataclass, field
+from typing import Annotated, Any
 from uuid import UUID, uuid4
 
+from .schema import Column, SchemaMixin, Unit
 from .tasks import Task, TaskRegistry
-from .schema import SchemaMixin, Column, Unit
 
 __all__ = ["MissionPlan"]
 

--- a/src/domain/schema.py
+++ b/src/domain/schema.py
@@ -1,7 +1,6 @@
 from dataclasses import MISSING, dataclass, fields
-from typing import (get_origin, get_args, get_type_hints,
-                    Annotated, Any, Type, Sequence)
 from enum import Enum
+from typing import Annotated, Any, Sequence, get_args, get_origin, get_type_hints
 
 __all__ = [
     "Unit",

--- a/src/domain/tasks.py
+++ b/src/domain/tasks.py
@@ -1,12 +1,11 @@
-from typing import TYPE_CHECKING, Annotated, ClassVar, TypeVar, Type, Callable, cast
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Annotated, Callable, ClassVar, Type, TypeVar, cast
 from uuid import UUID, uuid4
 
 from ..compat import StrEnum
 from .jsoncodec import JsonCodec
-from .schema import SchemaMixin, FieldSpec, Unit, Column, JsonKey
-from .waypoints import *
-
+from .schema import Column, SchemaMixin, Unit
+from .waypoints import AUVWaypoint, GeoPoint, Waypoint
 
 __all__ = [
     "Task",

--- a/src/domain/waraps.py
+++ b/src/domain/waraps.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
-from uuid import UUID
-from .schema import SchemaMixin, Column
-
 from typing import Annotated
+from uuid import UUID
+
+from .schema import Column, SchemaMixin
+
 
 @dataclass
 class WaraPsAvailableTask:

--- a/src/domain/waypoints.py
+++ b/src/domain/waypoints.py
@@ -1,9 +1,9 @@
-from typing import Annotated
 from dataclasses import dataclass, field
+from typing import Annotated
 from uuid import UUID, uuid4
 
-from .schema import Schema, SchemaMixin, Column, Unit
 from .jsoncodec import JsonCodec
+from .schema import Column, SchemaMixin, Unit
 
 __all__ = ["Waypoint", "AUVWaypoint", "GeoPoint"]
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,14 +1,15 @@
-from pathlib import Path
 import json
-import platform
 import os
+import platform
 import subprocess
+from pathlib import Path
 
-from qgis.PyQt.QtCore import QObject, Qt, QSize, pyqtSlot
-from qgis.PyQt.QtGui import QIcon
-from qgis.PyQt.QtWidgets import QAction, QDialog, QSizePolicy, QWidget, QMessageBox
+from qgis.core import QgsApplication
 from qgis.gui import QgisInterface
-from qgis.core import QgsProject, QgsApplication
+
+from qgis.PyQt.QtCore import QObject, QSize, Qt, pyqtSlot
+from qgis.PyQt.QtGui import QIcon
+from qgis.PyQt.QtWidgets import QAction, QMessageBox, QSizePolicy, QWidget
 
 from .context.FleetContext import FleetContext
 from .mission.MissionContext import MissionContext

--- a/src/mission/MissionContext.py
+++ b/src/mission/MissionContext.py
@@ -1,17 +1,17 @@
-from pathlib import Path
-from uuid import UUID, uuid4
 import json
+from pathlib import Path
+from uuid import UUID
 
-from qgis.PyQt.QtCore import pyqtSlot, pyqtSignal, QObject
-from qgis.core import QgsProject, QgsPointXY
+from qgis.core import QgsPointXY
 from qgis.utils import iface
 
-from .MissionMapManager import MissionMapManager
-from .MissionDocument import MissionDocument
+from qgis.PyQt.QtCore import QObject, pyqtSignal, pyqtSlot
+
 from ..domain.missionplan import MissionPlan
 from ..domain.tasks import PendingWaypointTask
 from ..domain.taskspatial import iterTaskWaypoints
-
+from .MissionDocument import MissionDocument
+from .MissionMapManager import MissionMapManager
 
 __all__ = ["MissionContext"]
 

--- a/src/mission/MissionDocument.py
+++ b/src/mission/MissionDocument.py
@@ -1,22 +1,41 @@
-from uuid import UUID, uuid4
-from typing import Any
-from pathlib import Path
 import json
+from pathlib import Path
+from typing import Any
+from uuid import UUID, uuid4
 
-from qgis.PyQt.QtCore import pyqtSlot, pyqtSignal, QObject
-from qgis.PyQt.QtWidgets import QUndoCommand
 from qgis.core import QgsPointXY
 
+from qgis.PyQt.QtCore import QObject, pyqtSignal
+
 from ..domain.missionplan import MissionPlan
+from ..domain.tasks import (
+    PendingWaypointTask,
+    Task,
+    TaskRegistry,
+    UnsupportedTaskCreationError,
+)
+from ..domain.taskspatial import (
+    iterTaskWaypoints,
+    locateTaskWaypoint,
+    waypointListFields,
+    waypointListType,
+    waypointType,
+)
 from ..domain.waypoints import Waypoint
-from ..domain.tasks import (Task, TaskRegistry, PendingWaypointTask,
-                            UnsupportedTaskCreationError)
-from ..domain.taskspatial import (iterTaskWaypoints, locateTaskWaypoint,
-                                  waypointListFields, waypointListType,
-                                  waypointType)
 from .MissionIndex import MissionIndex
 from .MissionLayerBridge import MissionLayerBridge
-from .MissionUndoCommand import *
+from .MissionUndoCommand import (
+    AddTaskUndoCommand,
+    AddWaypointUndoCommand,
+    DeleteTaskUndoCommand,
+    DeleteWaypointUndoCommand,
+    MissionUndoCommand,
+    SetMissionFieldUndoCommand,
+    SetTaskDescriptionUndoCommand,
+    SetTaskFieldUndoCommand,
+    SetWaypointFieldUndoCommand,
+    SetWaypointPositionUndoCommand,
+)
 
 
 class MissionDocument(QObject):

--- a/src/mission/MissionIndex.py
+++ b/src/mission/MissionIndex.py
@@ -2,9 +2,9 @@ from dataclasses import dataclass, field
 from uuid import UUID
 
 from ..domain.missionplan import MissionPlan
-from ..domain.waypoints import Waypoint
 from ..domain.tasks import Task
 from ..domain.taskspatial import iterTaskWaypoints
+from ..domain.waypoints import Waypoint
 
 
 @dataclass

--- a/src/mission/MissionLayerBridge.py
+++ b/src/mission/MissionLayerBridge.py
@@ -1,20 +1,31 @@
-from uuid import UUID
-from dataclasses import dataclass
 from contextlib import contextmanager
+from dataclasses import dataclass
+from uuid import UUID
 
-from qgis.PyQt.QtCore import pyqtSlot, pyqtSignal, QObject, QVariant
+from qgis.core import (
+    QgsFeature,
+    QgsFeatureRenderer,
+    QgsField,
+    QgsGeometry,
+    QgsLayerTreeGroup,
+    QgsPointXY,
+    QgsProject,
+    QgsProperty,
+    QgsSimpleMarkerSymbolLayer,
+    QgsSingleSymbolRenderer,
+    QgsSymbol,
+    QgsVectorLayer,
+)
+
+from qgis.PyQt.QtCore import QObject, QVariant, pyqtSignal, pyqtSlot
 from qgis.PyQt.QtGui import QColor
-from qgis.core import QgsProject, QgsField, QgsFeature, QgsVectorLayer, QgsGeometry, \
-    QgsPointXY, QgsLayerTreeGroup, QgsProperty, QgsSymbol, QgsSimpleMarkerSymbolLayer, \
-    QgsSingleSymbolRenderer, QgsFeatureRenderer
 
 from ..compat import StrEnum, assert_never
 from ..domain.missionplan import MissionPlan
-from ..domain.waypoints import Waypoint
 from ..domain.tasks import Task
 from ..domain.taskspatial import iterTaskWaypoints
+from ..domain.waypoints import Waypoint
 from .MissionTracks import MissionTracks
-
 
 __all__ = ["MissionLayerBridge"]
 

--- a/src/mission/MissionMapManager.py
+++ b/src/mission/MissionMapManager.py
@@ -1,17 +1,20 @@
 from dataclasses import dataclass
-from uuid import UUID, uuid4
+from uuid import UUID
 
-from qgis.PyQt import uic
-from qgis.PyQt.QtCore import *
-from qgis.PyQt.QtGui import *
-from qgis.PyQt.QtWidgets import *
-from qgis.gui import *
-from qgis.core import *
+from qgis.core import (
+    QgsCoordinateReferenceSystem,
+    QgsCoordinateTransform,
+    QgsPointXY,
+    QgsProject,
+)
+from qgis.gui import QgsMapCanvas, QgsMapMouseEvent, QgsMapTool, QgsRubberBand
 from qgis.utils import iface
 
-from ..domain.missionplan import MissionPlan
-from ..domain.tasks import PendingWaypointTask
+from qgis.PyQt.QtCore import QObject, Qt, pyqtSignal, pyqtSlot
+from qgis.PyQt.QtGui import QColor
+from qgis.PyQt.QtWidgets import QAction
 
+from ..domain.tasks import PendingWaypointTask
 
 __all__ = ["MissionMapManager"]
 

--- a/src/mission/MissionTracks.py
+++ b/src/mission/MissionTracks.py
@@ -1,13 +1,33 @@
-from ..domain.missionplan import MissionPlan
-from ..domain.waypoints import Waypoint
-from ..domain.taskspatial import iterTaskWaypoints
-
-from qgis.core import *
-from qgis.PyQt.QtCore import Qt, QObject, pyqtSlot, pyqtSignal, QVariant, QSizeF
-from qgis.PyQt.QtGui import QColor
-
 from uuid import UUID
 
+from qgis.core import (
+    Qgis,
+    QgsFeature,
+    QgsFeatureRenderer,
+    QgsField,
+    QgsGeometry,
+    QgsLayerTreeGroup,
+    QgsLineString,
+    QgsMarkerLineSymbolLayer,
+    QgsPointXY,
+    QgsProject,
+    QgsProperty,
+    QgsSimpleLineSymbolLayer,
+    QgsSimpleMarkerSymbolLayer,
+    QgsSingleSymbolRenderer,
+    QgsSymbol,
+    QgsTextBackgroundSettings,
+    QgsTextFormat,
+    QgsVectorLayer,
+    QgsVectorLayerSimpleLabeling,
+)
+
+from qgis.PyQt.QtCore import QObject, QSizeF, Qt, QVariant, pyqtSlot
+from qgis.PyQt.QtGui import QColor
+
+from ..domain.missionplan import MissionPlan
+from ..domain.taskspatial import iterTaskWaypoints
+from ..domain.waypoints import Waypoint
 
 __all__ = ["MissionTracks"]
 

--- a/src/mission/MissionTracks.py
+++ b/src/mission/MissionTracks.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from qgis.core import (
@@ -29,11 +32,15 @@ from ..domain.missionplan import MissionPlan
 from ..domain.taskspatial import iterTaskWaypoints
 from ..domain.waypoints import Waypoint
 
+if TYPE_CHECKING:
+    # Prevent circular dependencies
+    from .MissionDocument import MissionDocument
+
 __all__ = ["MissionTracks"]
 
 
 class MissionTracks(QObject):
-    _doc: 'MissionDocument'
+    _doc: MissionDocument
     _layer: QgsVectorLayer
     _activeRenderer: QgsFeatureRenderer
     _inactiveRenderer: QgsFeatureRenderer
@@ -48,7 +55,7 @@ class MissionTracks(QObject):
     COLOR_INACTIVE = QColor("#666666")
     COLOR_ACTIVE = QColor("#7040A0")
 
-    def __init__(self, doc: 'MissionDocument', layerGroup: QgsLayerTreeGroup,
+    def __init__(self, doc: MissionDocument, layerGroup: QgsLayerTreeGroup,
                  parent: QObject | None = None):
         super().__init__(parent)
 

--- a/src/mission/MissionUndoCommand.py
+++ b/src/mission/MissionUndoCommand.py
@@ -1,14 +1,9 @@
-from uuid import UUID
 from typing import Any
 
-from qgis.PyQt.QtCore import pyqtSlot, pyqtSignal, QObject
 from qgis.PyQt.QtWidgets import QUndoCommand
-from qgis.core import QgsPointXY
 
-from ..domain.missionplan import MissionPlan
-from ..domain.waypoints import Waypoint
 from ..domain.tasks import Task
-
+from ..domain.waypoints import Waypoint
 
 __all__ = [
     "MissionUndoCommand",

--- a/src/mission/MissionUndoCommand.py
+++ b/src/mission/MissionUndoCommand.py
@@ -1,9 +1,15 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from qgis.PyQt.QtWidgets import QUndoCommand
 
 from ..domain.tasks import Task
 from ..domain.waypoints import Waypoint
+
+if TYPE_CHECKING:
+    # Prevent circular dependencies
+    from .MissionDocument import MissionDocument
 
 __all__ = [
     "MissionUndoCommand",
@@ -19,9 +25,9 @@ __all__ = [
 ]
 
 class MissionUndoCommand(QUndoCommand):
-    _doc: 'MissionDocument'
+    _doc: MissionDocument
 
-    def __init__(self, doc: 'MissionDocument') -> None:
+    def __init__(self, doc: MissionDocument) -> None:
         super().__init__()
 
         self._doc = doc
@@ -29,7 +35,7 @@ class MissionUndoCommand(QUndoCommand):
 class AddTaskUndoCommand(MissionUndoCommand):
     _task: Task
 
-    def __init__(self, doc: 'MissionDocument', task: Task) -> None:
+    def __init__(self, doc: MissionDocument, task: Task) -> None:
         super().__init__(doc)
 
         self._task = task
@@ -46,7 +52,7 @@ class AddTaskUndoCommand(MissionUndoCommand):
 class DeleteTaskUndoCommand(MissionUndoCommand):
     _task: Task
 
-    def __init__(self, doc: 'MissionDocument', task: Task) -> None:
+    def __init__(self, doc: MissionDocument, task: Task) -> None:
         super().__init__(doc)
 
         self._task = task
@@ -64,7 +70,7 @@ class AddWaypointUndoCommand(MissionUndoCommand):
     _task: Task
     _waypoint: Waypoint
 
-    def __init__(self, doc: 'MissionDocument', task: Task, fieldName: str,
+    def __init__(self, doc: MissionDocument, task: Task, fieldName: str,
                  waypoint: Waypoint) -> None:
         super().__init__(doc)
 
@@ -86,7 +92,7 @@ class DeleteWaypointUndoCommand(MissionUndoCommand):
     _task: Task
     _waypoint: Waypoint
 
-    def __init__(self, doc: 'MissionDocument', task: Task, fieldName: str,
+    def __init__(self, doc: MissionDocument, task: Task, fieldName: str,
                  waypoint: Waypoint) -> None:
         super().__init__(doc)
 
@@ -109,7 +115,7 @@ class SetWaypointPositionUndoCommand(MissionUndoCommand):
     _newPos: tuple[float, float]
     _oldPos: tuple[float, float]
 
-    def __init__(self, doc: 'MissionDocument', waypoint: Waypoint, latitude: float,
+    def __init__(self, doc: MissionDocument, waypoint: Waypoint, latitude: float,
                  longitude: float):
         super().__init__(doc)
 
@@ -130,7 +136,7 @@ class SetWaypointFieldUndoCommand(MissionUndoCommand):
     _value: Any
     _oldValue: Any
 
-    def __init__(self, doc: 'MissionDocument', waypoint: Waypoint, fieldId: int,
+    def __init__(self, doc: MissionDocument, waypoint: Waypoint, fieldId: int,
                  value: Any, oldValue: Any):
         super().__init__(doc)
 
@@ -153,7 +159,7 @@ class SetTaskFieldUndoCommand(MissionUndoCommand):
     _value: Any
     _oldValue: Any
 
-    def __init__(self, doc: 'MissionDocument', task: Task, fieldId: int, value: Any,
+    def __init__(self, doc: MissionDocument, task: Task, fieldId: int, value: Any,
                  oldValue: Any):
         super().__init__(doc)
 
@@ -175,7 +181,7 @@ class SetTaskDescriptionUndoCommand(MissionUndoCommand):
     _value: str
     _oldValue: str
 
-    def __init__(self, doc: 'MissionDocument', task: Task, value: str, oldValue: str):
+    def __init__(self, doc: MissionDocument, task: Task, value: str, oldValue: str):
         super().__init__(doc)
 
         self._task = task
@@ -194,7 +200,7 @@ class SetMissionFieldUndoCommand(MissionUndoCommand):
     _value: Any
     _oldValue: Any
 
-    def __init__(self, doc: 'MissionDocument', fieldId: int, value: Any, oldValue: Any):
+    def __init__(self, doc: MissionDocument, fieldId: int, value: Any, oldValue: Any):
         super().__init__(doc)
 
         self._fieldId = fieldId

--- a/src/model/ItemBasedModel.py
+++ b/src/model/ItemBasedModel.py
@@ -1,8 +1,7 @@
-from qgis.PyQt.QtCore import Qt, QAbstractTableModel, QModelIndex
-from qgis.PyQt.QtGui import QValidator
-from qgis.PyQt.QtWidgets import QWidget
-
 from typing import Any, Sequence
+
+from qgis.PyQt.QtCore import QAbstractTableModel, QModelIndex, Qt
+from qgis.PyQt.QtWidgets import QWidget
 
 __all__ = ["ItemBasedModel"]
 

--- a/src/model/MissionParamsModel.py
+++ b/src/model/MissionParamsModel.py
@@ -1,10 +1,9 @@
-from qgis.PyQt.QtCore import Qt, pyqtSlot, QVariant, QModelIndex
+from qgis.PyQt.QtCore import QModelIndex, Qt, QVariant, pyqtSlot
 from qgis.PyQt.QtWidgets import QWidget
 
 from ..domain.missionplan import MissionPlan
 from ..mission.MissionDocument import MissionDocument
 from .SchemaBasedModel import SchemaBasedModel
-
 
 __all__ = ["MissionParamsModel"]
 

--- a/src/model/SchemaBasedModel.py
+++ b/src/model/SchemaBasedModel.py
@@ -1,4 +1,4 @@
-from qgis.PyQt.QtCore import Qt, QVariant, QModelIndex
+from qgis.PyQt.QtCore import QModelIndex, Qt
 from qgis.PyQt.QtWidgets import QWidget
 
 from ..domain.schema import Schema

--- a/src/model/TaskListModel.py
+++ b/src/model/TaskListModel.py
@@ -1,11 +1,6 @@
-from qgis.PyQt import uic
-from qgis.PyQt.QtCore import *
-from qgis.PyQt.QtGui import *
-from qgis.PyQt.QtWidgets import *
-from qgis.gui import *
-from qgis.core import *
-
 from uuid import UUID
+
+from qgis.PyQt.QtCore import QModelIndex, Qt, QVariant, pyqtSlot
 
 from ..domain.tasks import Task
 from ..mission.MissionDocument import MissionDocument

--- a/src/model/TaskParamsModel.py
+++ b/src/model/TaskParamsModel.py
@@ -1,15 +1,9 @@
-from qgis.PyQt import uic
-from qgis.PyQt.QtCore import *
-from qgis.PyQt.QtGui import *
-from qgis.PyQt.QtWidgets import *
-from qgis.gui import *
-from qgis.core import *
-
-from typing import *
+from typing import Type
 from uuid import UUID
 
+from qgis.PyQt.QtCore import QModelIndex, Qt, QVariant, pyqtSlot
+
 from ..domain.tasks import Task
-from ..domain.schema import Schema
 from ..mission.MissionDocument import MissionDocument
 from .SchemaBasedModel import SchemaBasedModel
 

--- a/src/model/WaypointListModel.py
+++ b/src/model/WaypointListModel.py
@@ -1,18 +1,10 @@
-from qgis.PyQt import uic
-from qgis.PyQt.QtCore import *
-from qgis.PyQt.QtGui import *
-from qgis.PyQt.QtWidgets import *
-from qgis.gui import *
-from qgis.core import *
-
-from typing import *
 from uuid import UUID
 
-from ..mission.MissionDocument import MissionDocument
-from ..domain.waypoints import Waypoint
+from qgis.PyQt.QtCore import QModelIndex, Qt, QVariant, pyqtSlot
+
 from ..domain.tasks import Task
-from ..domain.schema import Schema
 from ..domain.taskspatial import isWaypointField, isWaypointListField
+from ..mission.MissionDocument import MissionDocument
 from .SchemaBasedModel import SchemaBasedModel
 
 __all__ = ["WaypointListModel"]

--- a/src/ui/widgets/AddTaskDialog.py
+++ b/src/ui/widgets/AddTaskDialog.py
@@ -1,7 +1,6 @@
-from qgis.PyQt.QtWidgets import QWidget, QDialog
+from qgis.PyQt.QtWidgets import QDialog, QWidget
 
 from ...domain.tasks import TaskRegistry
-
 from ..generated.AddTaskDialogUi import Ui_AddTaskDialog
 
 __all__ = ["AddTaskDialog"]

--- a/src/ui/widgets/AutomaticFormWidget.py
+++ b/src/ui/widgets/AutomaticFormWidget.py
@@ -1,11 +1,17 @@
-from typing import Type
 from enum import Enum
+from typing import Type
 
-from qgis.PyQt.QtCore import Qt, pyqtSlot, pyqtSignal
-from qgis.PyQt.QtGui import QIntValidator, QDoubleValidator
-from qgis.PyQt.QtWidgets import QWidget, QFormLayout, QLabel, QComboBox, QLineEdit, QDataWidgetMapper, QCheckBox
-
-from ...domain.schema import Schema
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtGui import QDoubleValidator, QIntValidator
+from qgis.PyQt.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDataWidgetMapper,
+    QFormLayout,
+    QLabel,
+    QLineEdit,
+    QWidget,
+)
 
 __all__ = ["AutomaticFormWidget"]
 

--- a/src/ui/widgets/FleetControlWidget.py
+++ b/src/ui/widgets/FleetControlWidget.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from qgis.PyQt.QtCore import Qt, QTimer, pyqtSignal, pyqtSlot
 from qgis.PyQt.QtWidgets import QFrame, QWidget
 

--- a/src/ui/widgets/FleetControlWidget.py
+++ b/src/ui/widgets/FleetControlWidget.py
@@ -1,6 +1,5 @@
-from qgis.PyQt.QtCore import Qt, pyqtSlot, pyqtSignal, QTimer
-from qgis.PyQt.QtWidgets import QWidget, QFrame
-from qgis.core import QgsApplication
+from qgis.PyQt.QtCore import Qt, QTimer, pyqtSignal, pyqtSlot
+from qgis.PyQt.QtWidgets import QFrame, QWidget
 
 from ...context.FleetState import FleetState
 from ..generated.FleetControlWidgetUi import Ui_FleetControlWidget

--- a/src/ui/widgets/LiveViewWidget.py
+++ b/src/ui/widgets/LiveViewWidget.py
@@ -1,15 +1,10 @@
-from qgis.PyQt import uic
-from qgis.PyQt.QtCore import *
-from qgis.PyQt.QtGui import *
-from qgis.PyQt.QtWidgets import *
-from qgis.gui import *
-from qgis.core import *
-from qgis.utils import iface
-from pathlib import Path
+from qgis.PyQt.QtCore import Qt, pyqtSlot
+from qgis.PyQt.QtWidgets import QWidget
 
 from ...context.FleetContext import FleetContext
 from ..generated.LiveViewWidgetUi import Ui_LiveViewWidget
 from .VehicleLiveViewWidget import VehicleLiveViewWidget
+
 
 class LiveViewWidget(QWidget):
     _fleetContext: FleetContext

--- a/src/ui/widgets/MissionControlDockWidget.py
+++ b/src/ui/widgets/MissionControlDockWidget.py
@@ -1,21 +1,19 @@
 from pathlib import Path
 
-from qgis.PyQt import uic
-from qgis.PyQt.QtCore import *
-from qgis.PyQt.QtGui import *
-from qgis.PyQt.QtWidgets import *
-from qgis.gui import *
-from qgis.core import *
+from qgis.core import QgsApplication
+from qgis.gui import QgsDockWidget
 from qgis.utils import iface
 
-from ...domain.missionplan import MissionPlan
+from qgis.PyQt.QtCore import QCoreApplication, pyqtSlot
+from qgis.PyQt.QtWidgets import QDialog, QFileDialog, QMessageBox, QWidget
+
+from ...context.FleetContext import FleetContext
 from ...mission.MissionContext import MissionContext
 from ...mission.MissionDocument import MissionDocument
-from ...context.FleetContext import FleetContext
 from ..generated.MissionControlDockWidgetUi import Ui_MissionControlDockWidget
-from .MissionPlanWidget import MissionPlanWidget
 from .FleetControlWidget import FleetControlWidget
 from .LiveViewWidget import LiveViewWidget
+from .MissionPlanWidget import MissionPlanWidget
 
 
 class MissionControlDockWidget(QgsDockWidget):
@@ -128,7 +126,7 @@ class MissionControlDockWidget(QgsDockWidget):
         self.retranslateUi2()
 
     def retranslateUi2(self):
-        _translate = QtCore.QCoreApplication.translate
+        _translate = QCoreApplication.translate
         self.ui.tabWidget.setTabText(
             self.ui.tabWidget.indexOf(self.ui.tabMissionPlan),
             _translate("MissionControlDockWidget", "Mission Pla&n"),

--- a/src/ui/widgets/MissionPlanWidget.py
+++ b/src/ui/widgets/MissionPlanWidget.py
@@ -1,19 +1,25 @@
 from uuid import UUID
 
-from qgis.PyQt.QtCore import Qt, pyqtSignal, pyqtSlot, QItemSelection
-from qgis.PyQt.QtWidgets import (QWidget, QHeaderView, QAbstractItemDelegate, QDialog,
-                                 QDataWidgetMapper, QMessageBox)
 from qgis.core import QgsApplication
 
+from qgis.PyQt.QtCore import QItemSelection, Qt, pyqtSignal, pyqtSlot
+from qgis.PyQt.QtWidgets import (
+    QAbstractItemDelegate,
+    QDataWidgetMapper,
+    QDialog,
+    QHeaderView,
+    QMessageBox,
+    QWidget,
+)
+
+from ...domain.tasks import TaskRegistry, UnsupportedTaskCreationError
 from ...mission.MissionContext import MissionContext
 from ...mission.MissionDocument import MissionDocument
-from ...domain.missionplan import MissionPlan
-from ...domain.tasks import TaskRegistry, UnsupportedTaskCreationError
-from ...model.TaskListModel import TaskListModel
 from ...model.MissionParamsModel import MissionParamsModel
+from ...model.TaskListModel import TaskListModel
 from ..generated.MissionPlanWidgetUi import Ui_MissionPlanWidget
-from .TaskEditorWidget import TaskEditorWidget
 from .AddTaskDialog import AddTaskDialog
+from .TaskEditorWidget import TaskEditorWidget
 
 
 class MissionPlanWidget(QWidget):

--- a/src/ui/widgets/MqttConnectionDialog.py
+++ b/src/ui/widgets/MqttConnectionDialog.py
@@ -1,5 +1,5 @@
-from qgis.PyQt.QtWidgets import QWidget, QDialog
 from qgis.PyQt.QtCore import pyqtSignal
+from qgis.PyQt.QtWidgets import QDialog, QWidget
 
 from ..generated.MqttConnectionDialogUi import Ui_MqttConnectionDialog
 

--- a/src/ui/widgets/TaskEditorWidget.py
+++ b/src/ui/widgets/TaskEditorWidget.py
@@ -1,22 +1,15 @@
-from qgis.PyQt import uic
-from qgis.PyQt.QtCore import *
-from qgis.PyQt.QtGui import *
-from qgis.PyQt.QtWidgets import *
-from qgis.gui import *
-from qgis.core import *
-
-from typing import *
-from dataclasses import replace as dtReplace
 from enum import Enum
-from uuid import UUID, uuid4
+from typing import Type
+from uuid import UUID
+
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtWidgets import QFormLayout, QLabel, QSizePolicy, QWidget
 
 from ...domain.tasks import Task
-from ...domain.schema import Schema
 from ...domain.taskspatial import waypointListType, waypointType
 from ...mission.MissionContext import MissionContext
 from ...mission.MissionDocument import MissionDocument
 from ...model.TaskParamsModel import TaskParamsModel
-
 from .AutomaticFormWidget import AutomaticFormWidget
 from .WaypointFormWidget import WaypointFormWidget
 from .WaypointTableWidget import WaypointTableWidget

--- a/src/ui/widgets/VehicleCardWidget.py
+++ b/src/ui/widgets/VehicleCardWidget.py
@@ -1,15 +1,13 @@
-from qgis.PyQt.QtCore import *
-from qgis.PyQt.QtGui import *
-from qgis.PyQt.QtWidgets import *
-from qgis.gui import *
-from qgis.core import *
+from qgis.core import QgsApplication
 
-from ..generated.VehicleCardWidgetUi import Ui_VehicleCardWidget
+from qgis.PyQt.QtCore import QSignalBlocker, QSize, Qt, pyqtSignal, pyqtSlot
+from qgis.PyQt.QtGui import QMovie
+from qgis.PyQt.QtWidgets import QHeaderView, QWidget
+
+from ...context.FleetState import VehicleState
 from ...domain.waraps import WaraPsExecutingTask
 from ...model.SchemaBasedModel import SchemaBasedModel
-from ...context.FleetState import VehicleState
-from typing import *
-from dataclasses import dataclass
+from ..generated.VehicleCardWidgetUi import Ui_VehicleCardWidget
 
 
 class VehicleCardWidget(QWidget):

--- a/src/ui/widgets/VehicleLiveViewWidget.py
+++ b/src/ui/widgets/VehicleLiveViewWidget.py
@@ -1,14 +1,10 @@
 from math import degrees
-from functools import partial
 
-from qgis.PyQt import uic
-from qgis.PyQt.QtCore import *
-from qgis.PyQt.QtGui import *
-from qgis.PyQt.QtWidgets import *
-from qgis.gui import *
-from qgis.core import *
-from qgis.utils import iface
-from qgis.PyQt.QtGui import QMovie
+from qgis.core import QgsApplication
+
+from qgis.PyQt.QtCore import QSignalBlocker, QSize, Qt, pyqtSignal, pyqtSlot
+from qgis.PyQt.QtGui import QColor, QMovie
+from qgis.PyQt.QtWidgets import QWidget
 
 from ...context.FleetState import VehicleState
 from ..generated.VehicleLiveViewWidgetUi import Ui_VehicleLiveViewWidget

--- a/src/ui/widgets/WaypointFormWidget.py
+++ b/src/ui/widgets/WaypointFormWidget.py
@@ -1,20 +1,15 @@
-from qgis.PyQt.QtWidgets import QWidget
-from qgis.core import QgsApplication, QgsVectorLayer
-
-from qgis.PyQt import uic
-from qgis.PyQt.QtCore import *
-from qgis.PyQt.QtGui import *
-from qgis.PyQt.QtWidgets import *
-from qgis.gui import *
-from qgis.core import *
-
 from typing import Type
 from uuid import UUID
 
-from ...mission.MissionContext import MissionContext
-from ...mission.MissionDocument import MissionDocument
+from qgis.core import QgsApplication
+
+from qgis.PyQt.QtCore import pyqtSignal, pyqtSlot
+from qgis.PyQt.QtWidgets import QAction, QWidget
+
 from ...domain.tasks import Task
 from ...domain.waypoints import Waypoint
+from ...mission.MissionContext import MissionContext
+from ...mission.MissionDocument import MissionDocument
 from ...model.WaypointListModel import WaypointListModel
 from ..generated.WaypointFormWidgetUi import Ui_WaypointFormWidget
 from .AutomaticFormWidget import AutomaticFormWidget

--- a/src/ui/widgets/WaypointTableWidget.py
+++ b/src/ui/widgets/WaypointTableWidget.py
@@ -1,18 +1,15 @@
-from qgis.PyQt import uic
-from qgis.PyQt.QtCore import *
-from qgis.PyQt.QtGui import *
-from qgis.PyQt.QtWidgets import *
-from qgis.gui import *
-from qgis.core import *
+from typing import Type
 from uuid import UUID
 
-from typing import Type
-from dataclasses import replace as dtReplace
+from qgis.core import QgsApplication
 
-from ...mission.MissionContext import MissionContext
-from ...mission.MissionDocument import MissionDocument
+from qgis.PyQt.QtCore import QItemSelection, Qt, pyqtSignal, pyqtSlot
+from qgis.PyQt.QtWidgets import QAbstractItemDelegate, QAction, QHeaderView, QWidget
+
 from ...domain.tasks import Task
 from ...domain.waypoints import Waypoint
+from ...mission.MissionContext import MissionContext
+from ...mission.MissionDocument import MissionDocument
 from ...model.WaypointListModel import WaypointListModel
 from ..generated.WaypointTableWidgetUi import Ui_WaypointTableWidget
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,175 @@
+version = 1
+revision = 3
+requires-python = "==3.10.*"
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/2f/ec5241c38e7fa0fe6c26bfc450e78b9489a6c3c08b394b85d2c10e506975/librt-0.13.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:34e47058fcc69a313293d6dee94216a4f30c929ae6f2476e58c5ba635aa639d5", size = 148654, upload-time = "2026-07-08T12:24:30.622Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/1a/d651e18d3ee7aa2879322368c4f278bb7ecaa6b90caadfdec4ebfa8389f3/librt-0.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dbdd5b6509d0c2a8fe72cf494c299a61dbd58142a90a4190664ae159e4a7b547", size = 153537, upload-time = "2026-07-08T12:24:31.773Z" },
+    { url = "https://files.pythonhosted.org/packages/45/18/10bff2122577246009d9619b6569596daf69b7648812f997ca9ca0426f60/librt-0.13.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e56ea4ee4df77585a6b5c138f6538680886024fa559f5b55bd14b12e98e67b2", size = 494336, upload-time = "2026-07-08T12:24:33.079Z" },
+    { url = "https://files.pythonhosted.org/packages/67/69/87dfee871b852970f137fdeae8e2ca356c5ab38e6f21d2a3299535fc3159/librt-0.13.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f1f9cc4d09a46d9cb3c2063ae100629d3f52a6517c3c08c2f4c9828261883929", size = 485393, upload-time = "2026-07-08T12:24:34.324Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d5/625447a8c0441ff5f15f4ac5e1d323fb9d4d256ebfde7a3c8e003f646057/librt-0.13.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f125f5d46b20f89dc5587a55cc416b4ba2a5b2ffda36d048ee120e17598a653a", size = 515382, upload-time = "2026-07-08T12:24:35.575Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/d8/1c8c49ea04235960426444deece9092a6b3a9587a850a81bae2335317411/librt-0.13.0-cp310-cp310-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2608d3b39f9e0b4a66a130d9150c615cba40a5090d25eeeaa225e0e46de8c0ac", size = 509483, upload-time = "2026-07-08T12:24:36.923Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/65/f1760fc48050e215201a03506c32b7270159088d01f64557b53e39e74a45/librt-0.13.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:9fd35e95ab5e45c3901d37110263c7db85a961110f5460588fe37f8c131f88a7", size = 532503, upload-time = "2026-07-08T12:24:38.203Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1b/793e281dcf494879eff99f642b63ebc9c7c58694a1c2d1e93362a22c7041/librt-0.13.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:5f31b0aa13c9b04370d4da6be1ab7779776b3a075cceb6747a39a4be85fe1e40", size = 537027, upload-time = "2026-07-08T12:24:39.34Z" },
+    { url = "https://files.pythonhosted.org/packages/69/45/0801bbb40c9eea795d3dd3ce91c4c5f3fe7d42d23ec4be3e8cb283bcc754/librt-0.13.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:0b795f5fc70fbbb787ceaf79bb3a0d627bcc33c53de51741755263ec406b775a", size = 517100, upload-time = "2026-07-08T12:24:40.907Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/6c/eb5f514f8e29d4924bc0ff4601dd7b4175557e182e7c0721e84cffa39b8a/librt-0.13.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:36b306a623aaad96fe4b378692b54f9c0789fccd833b9851753d5fbf6138cfde", size = 558653, upload-time = "2026-07-08T12:24:42.359Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/bf/f140100d1b59fe87ff40b5ecbb4e27924335b189a784e230ee465452f6c2/librt-0.13.0-cp310-cp310-win32.whl", hash = "sha256:a3762e75fcac8c9e4dacaaf438bffd9003e2ca2c531b756f3c0035deefa674c8", size = 104402, upload-time = "2026-07-08T12:24:43.668Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7c/57e40fef7cfb61869341cb28bdcefe8a950bebcbecca74a397bae14dce4a/librt-0.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:d63bae12a8aeb51380be3438e4dc4bd27354d0f8e19166b2f44e3e94d6f552dc", size = 125002, upload-time = "2026-07-08T12:24:44.793Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "tomli" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/09/f2f5f45dae0c9a0891e4751a73312730e009395102e5d72a22a976cca41f/mypy-2.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1fa8d916ac3b705af733c4c1e6c9ebe38fd0d52beb15b105c3e8355b55e6ecdc", size = 14927774, upload-time = "2026-07-13T11:28:38.224Z" },
+    { url = "https://files.pythonhosted.org/packages/56/b9/345367effd3a6877275a94d481614bfca983f45e028c6290e2cc54603811/mypy-2.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:28e1e2af8cd8fff551fd30f2fe4b03fb76764ac8b1ba6c6a1bd00ad32b412db3", size = 14000127, upload-time = "2026-07-13T11:30:19.57Z" },
+    { url = "https://files.pythonhosted.org/packages/99/6c/a10b7a7b9f0a755fb94e27ae834d4cea9ad6c5221f9325eef8f182641feb/mypy-2.3.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3e77244df3843048c3f927182916730e40c124cbaa43905c1fb86cb382aa0805", size = 14229437, upload-time = "2026-07-13T11:28:17.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/bd/a26a602acb1bbf849fa4bdac4bc657ee2f11c0c2a764a2cc87a5304e865c/mypy-2.3.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9559ab18a9c9957dfa3004ab57cd4bac5f26a724329a9584e583367f0c2e1117", size = 15171457, upload-time = "2026-07-13T11:29:01.834Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/14/124f462bef69bcbc90b9358088460b6091954a3e004852fcd9948db617a5/mypy-2.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:09abd66d8685e73f8f7d17b847c3e104d9a7b164a8706ea87d6c96a3d45816d5", size = 15478281, upload-time = "2026-07-13T11:32:23.413Z" },
+    { url = "https://files.pythonhosted.org/packages/db/a4/8bdca6a8ac8d856d82ed049144af2721245a135c2e8001d3890c93975852/mypy-2.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:5e91adad1ca81742ac7ef9893959911df867752206b37135185e88dfb3c89494", size = 11148008, upload-time = "2026-07-13T11:34:17.332Z" },
+    { url = "https://files.pythonhosted.org/packages/83/41/490eea348e60ba50decec20bc750605444149a5d7a8cc560042f90ba2c75/mypy-2.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:6f99ec626e3c3a2f7c0b22c5b90ddb5dabb1c18729c971e9bdaca1f1766d2cee", size = 10142329, upload-time = "2026-07-13T11:32:52.116Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pyqt5-stubs"
+version = "5.15.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/5b/f96312e01661dff7320366fc948f7597d3e3e28ff7116e9e77dbf41ab937/PyQt5-stubs-5.15.6.0.tar.gz", hash = "sha256:91270ac23ebf38a1dc04cd97aa852cd08af82dc839100e5395af1447e3e99707", size = 395647, upload-time = "2022-04-23T09:53:56.785Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/d5/9b8482ed572be40d51c3fcbb87451e446e56b5e19487cd60340b8ef51eb4/PyQt5_stubs-5.15.6.0-py3-none-any.whl", hash = "sha256:7fb8177c72489a8911f021b7bd7c33f12c87f6dba92dcef3fdcdb5d9400f0f3f", size = 433328, upload-time = "2022-04-23T09:53:52.107Z" },
+]
+
+[[package]]
+name = "qgis-stubs"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyqt5-stubs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/f5/00d4c719f72ecd9236781e09eb931aa3a5dfd496508a94923eaed43057cc/qgis_stubs-0.4.0.tar.gz", hash = "sha256:8c0f3b9404448e6e5772b5875597c0d5f5576025e0f9df46ab55fbfb6644944d", size = 742366, upload-time = "2026-06-13T13:52:47.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/91/3848e7f340e853e855733a33ef6aadc128392e0fa4c3f511a843bab50a86/qgis_stubs-0.4.0-py3-none-any.whl", hash = "sha256:58ef590eafbacd2f672759270a56d15970c61445292a1f3fda7a6c40a4b384ff", size = 762788, upload-time = "2026-06-13T13:52:46.004Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/25/7113f6d5498888c5fb7db34081cba7d5971c4cb1bfb26819966eee68f003/ruff-0.16.1.tar.gz", hash = "sha256:fedad7c801dabd3fb9741d76aca39246e6ddd9ca446a015875207bf19f1e6bc7", size = 4877500, upload-time = "2026-07-30T19:37:01.379Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/bd/694da69368e0973de65df2ddc73ab18d43c469d5963d9b150911de6bc513/ruff-0.16.1-py3-none-linux_armv6l.whl", hash = "sha256:58edb313b88f0c5460a26adf5f39a37a3be789494a15e3e411e35fa78b89f9a0", size = 10839126, upload-time = "2026-07-30T19:36:13.697Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/f0/b626e5d5bd0dd9576263658ef12885e2288afd1029a48e26ffed65ec1ac1/ruff-0.16.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fde5a99e2f97479af66edd6622c6d5a2a7592c77cf4153d9e4428f5eeb55b60c", size = 11070253, upload-time = "2026-07-30T19:36:17.14Z" },
+    { url = "https://files.pythonhosted.org/packages/83/63/f40acfb6b35b88623e71684942b552c3edd96035f5d98f313815f7b277de/ruff-0.16.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e0d4c20532fca4f7fa609369161d968dd28f65d83dabbd61d8e9c7edbf7001f6", size = 10561425, upload-time = "2026-07-30T19:36:20.04Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/dd/14ec0e9c2b4d315547dd38765004b4863e354e1b52cb308272215d9f6f6d/ruff-0.16.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30affbcedf59ad5703d9c91f82266e02b47739f797e1a7b6e158e5526a6dae38", size = 10948879, upload-time = "2026-07-30T19:36:22.476Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e9/9d870cbae575030fdef595f04b4b97573c525b5497cce4f4498cf2f85446/ruff-0.16.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:24e9c631573cbca9d20f1283f8f479b2afa4a8503504822bd71a293889f16743", size = 10643691, upload-time = "2026-07-30T19:36:24.914Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/09/12743d544e2173f53ecd27217c65f90d2bc0f8424a66a60339e56bbc0457/ruff-0.16.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b41bdd48fb420987a9b5212e4957c26ad4abce401fa9ea9d4d85843727945f4f", size = 11435354, upload-time = "2026-07-30T19:36:28.447Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/89/a1652b2daee52083c9554a6333b678a8b01d0400f976827bb87857f9449a/ruff-0.16.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b0d1e1393b7648079e13669de1c1f4fde06d4583e84d8fd5c1551e0a77a2aa75", size = 12259033, upload-time = "2026-07-30T19:36:31.326Z" },
+    { url = "https://files.pythonhosted.org/packages/16/96/ecdcb8c54ee7b123b487f807eb014e6e019155a0b81dfb669acd52f28ce3/ruff-0.16.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:07bf434b1c95f4e093be4532068ef4fcf00924eb2ade8796075980902d6fd54a", size = 11667981, upload-time = "2026-07-30T19:36:34.394Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/90/c52e12e0d862e9572f2a33aa227409143520abe53111e9a6babbac7b4af8/ruff-0.16.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39897739f112253ee4fdd2e8aa9a4f9ded99fb2be367d5f31dfa4ded6025584c", size = 11468183, upload-time = "2026-07-30T19:36:37.339Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6b/4ffb7ad1d83eb16cf8cbb3c8815d3f11c88460fd162d4b372a2059be1c2a/ruff-0.16.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:82ae3c0c0d74daf17b968a10b7b3bb3ef297ab7de0c1f749646b25e690ccb150", size = 11470071, upload-time = "2026-07-30T19:36:39.91Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/72/32ae7db4c0b5e32ab611787caa19d1546800676d79f7483b7100a3561bf4/ruff-0.16.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4d5f2ed10f8242d83fc08d521301089364e3375375705356f20c0e31606ef3ef", size = 10919503, upload-time = "2026-07-30T19:36:42.65Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ca/3d901ba6ad6fc38da39c3448fc6c59ac945679293a17c3ceb6d6c1cba13e/ruff-0.16.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a4665b309891f83f3e3c25447935f1213e9abbd4b5640af7a1f2def9f8d413c1", size = 10649861, upload-time = "2026-07-30T19:36:45.18Z" },
+    { url = "https://files.pythonhosted.org/packages/92/79/894ef1ced26552d5f8c9cf6d85b0687840e1128c55aeab7b9c2d54a0d880/ruff-0.16.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:26e9ca5c9bc3971f20d3cf18a957f52ffd6a5f6564ff15c4912a144dcac22494", size = 11148137, upload-time = "2026-07-30T19:36:47.936Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/69/3609a09fa1cb46cc28b762363e440a354204e5dff01bd0c8d7437874d6b9/ruff-0.16.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:67e1e1e3fa4f0c82f0e36d4cd61e661f6e7a6196cb1aa92fe0828fa7b8f257cd", size = 11559211, upload-time = "2026-07-30T19:36:50.448Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/8a/fb22af2fd78a736e241fabf67e30ce1799a64244026377a49e133af90762/ruff-0.16.1-py3-none-win32.whl", hash = "sha256:d31765e131295b8445caf301e3e8a85b34d1b9b211b4109b7ba457888b051806", size = 10838258, upload-time = "2026-07-30T19:36:53.298Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/35/e57fd9fb5d423961df087a00b12d42c0a830288dc2f3b45ecca299158b4f/ruff-0.16.1-py3-none-win_amd64.whl", hash = "sha256:09b05e8b90c2cb06ad63464350e7a45e8e44a2dfe52072ebfba6666ca8d3f596", size = 11961111, upload-time = "2026-07-30T19:36:56.107Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/46/240ea004bf6dc4feb40e9832f2205a476a47dd5b8a3f8211a5fc5f95e20e/ruff-0.16.1-py3-none-win_arm64.whl", hash = "sha256:dbaadaac38c70239f056d306b7476f246b0bf000fa6b3876402acbf5b227eaf8", size = 11309414, upload-time = "2026-07-30T19:36:58.79Z" },
+]
+
+[[package]]
+name = "smarc-qgis-mission-control"
+version = "0.0.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "qgis-stubs" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=2.3.0" },
+    { name = "qgis-stubs", specifier = ">=0.4.0" },
+    { name = "ruff", specifier = ">=0.16.1" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]


### PR DESCRIPTION
This PR cleans up imports in all our Python files, and adds configuration for `ruff` and `mypy` (see `pyproject.toml`).

## Development tooling
Development dependencies are managed with `uv` (see `uv.lock`).

Import checks can be run locally with:

```bash
uv run ruff check src/
```

Most issues can be fixed with:

```bash
uv run ruff check --fix src/
```

`pyproject.toml` also provides configuration for `mypy`. It can be run with:

```bash
uv run mypy src/
```

There are a bunch of issues which exist now. The point of this PR is that now mypy output is actually useful, as it doesn't complain constantly about wildcard imports.

## CI
This PR also adds a GitHub Actions workflow to run `ruff` import checks on new PRs to the `master` branch.